### PR TITLE
Ignore otelcol.dev.yaml config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ otelcol-dev
 .envrc
 .idea
 ocb
+
+# Ignore the development config file
+otelcol.dev.yaml

--- a/README.md
+++ b/README.md
@@ -48,6 +48,8 @@ You can start the Otel Collector with the predefined config:
 ./otelcol-dev/otelcol --config otelcol.yaml
 ```
 
+For local development, you can use the `otelcol.dev.yaml` config file which is ignored by default.
+
 
 ### Receiver Settings
 


### PR DESCRIPTION
For development, I find it useful to have my own local config file which is not accidentially commited to the repo. I have added this to the .gitinore file and added a remark to the README.