### PR TITLE
feat(es-otlp): Added basicauth extension

### DIFF
--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -27,3 +27,4 @@ receivers:
 
 extensions:
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/pprofextension v0.134.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/extension/basicauthextension v0.134.0


### PR DESCRIPTION
### 📝 Description

As described in the related issue, we want to include the newly introduced ES OTLP metric endpoint in the set of our regular metric benchmark tests.
In order to be able to connect to ES we need to provide a set of credentials username/password for performing the basic auth operation.

We prefer to offload the authn step to the OTLP collector via the respective extension, since it is considered a more idiomatic and clean solution versus injecting the Authentication header from the bench-run executor.

Via this PR we simply make the basicauth extension available for the collector config

---

### 💬 Notes for Reviewers

Manual testing was performed via the following command:
```
./otelcol-dev/otelcol --config ./otelcol.dev.yaml
```

and by using the following collector config
```
receivers:
  metricsgen:
    start_now_minus: 1h
    interval: 5s
    interval_jitter_std_dev: 1ms
    real_time: false
    exit_after_end: true
    seed: 123
    scenarios:
    - path: builtin/hostmetrics
      scale: 100

processors:
  batch:

extensions:
  basicauth/client:
    client_auth: 
      username: {{username}}
      password: {{password}}

exporters:
  debug:
    verbosity: detailed
  otlphttp/elasticsearch:
    compression: gzip
    encoding: proto
    endpoint: https://localhost:9200/_otlp
    auth:
      authenticator: basicauth/client
    sending_queue:
      enabled: true
      block_on_overflow: true
      queue_size: 10
      num_consumers: 10
    tls:
      insecure_skip_verify: true

service:
  extensions: [basicauth/client]
  pipelines:
    metrics:
      receivers: [metricsgen]
      processors: [batch]
      exporters: [otlphttp/elasticsearch]
```
