### PR TITLE
add clickhouse support

### DIFF
--- a/builder-config.yaml
+++ b/builder-config.yaml
@@ -9,6 +9,7 @@ exporters:
   - gomod: go.opentelemetry.io/collector/exporter/nopexporter v0.134.0
   - gomod: go.opentelemetry.io/collector/exporter/otlphttpexporter v0.134.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/fileexporter v0.134.0
+  - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter v0.134.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/elasticsearchexporter v0.134.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/opensearchexporter v0.134.0
   - gomod: github.com/open-telemetry/opentelemetry-collector-contrib/exporter/prometheusremotewriteexporter v0.134.0


### PR DESCRIPTION
### Description
add Clickhouse support, create new version with tag 1.06

### What this PR does

- adds clickhouse support by including github.com/open-telemetry/opentelemetry-collector-contrib/exporter/clickhouseexporter, this change is based on what we did for opensearch https://github.com/elastic/metricsgenreceiver/commit/1f92556f936b6a68a97ff76e749e5afafb1010e1



 