### PR TITLE
feat(realtime): fix timestamp lag and add run_indefinitely flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,8 +74,10 @@ receivers:
   It is capped by the interval, so that the next interval will never start at or before the previous one.
   This simulates real-world scenarios where the collection interval is sometimes a bit late due to delays running the scheduled metric collection.
   When set to a non-zero value, this can impact the effectiveness of the compression that a metric datastore may apply.
-* `real_time` (default `false`): by default, the receiver generates the metrics as fast as possible.
-  When set to true, it will pause after each cycle according to the configured `interval`.
+* `real_time` (default `false`): when set to true, the receiver will pace metric emission
+  to the configured `interval` instead of generating as fast as possible.
+* `run_indefinitely` (default `false`): when set to true, the receiver will generate metrics
+  indefinitely until stopped. Cannot be combined with `end_time` or `end_now_minus`.
 * `exit_after_end` (default `false`): when set to true, will terminate the collector.
 * `exit_after_end_timeout` (default `0`): timeout in case exit_after_end is set to true before the collector is terminated.
 * `seed` (default `0`): seed value for the random number generator that's used for simulating the standard distribution. The seed makes sure that the data generation is deterministic.
@@ -158,6 +160,28 @@ receivers:
     end_time: "2025-01-01T01:00:00Z"
     interval: 10s
     exit_after_end: true
+    seed: 123
+    scenarios:
+      - path: builtin/hostmetrics
+        scale: 100
+
+exporters:
+  nop:
+
+service:
+  pipelines:
+    metrics:
+      receivers: [metricsgen]
+      exporters: [nop]
+```
+
+Real-time mode, running indefinitely:
+```yaml
+receivers:
+  metricsgen:
+    interval: 10s
+    real_time: true
+    run_indefinitely: true
     seed: 123
     scenarios:
       - path: builtin/hostmetrics

--- a/metricsgenreceiver/config.go
+++ b/metricsgenreceiver/config.go
@@ -17,6 +17,7 @@ type Config struct {
 	Interval                          time.Duration                `mapstructure:"interval"`
 	IntervalJitterStdDev              time.Duration                `mapstructure:"interval_jitter_std_dev"`
 	RealTime                          bool                         `mapstructure:"real_time"`
+	RunIndefinitely                   bool                         `mapstructure:"run_indefinitely"`
 	ExitAfterEnd                      bool                         `mapstructure:"exit_after_end"`
 	ExitAfterEndTimeout               time.Duration                `mapstructure:"exit_after_end_timeout"`
 	Seed                              int64                        `mapstructure:"seed"`
@@ -73,6 +74,14 @@ func (cfg *Config) Validate() error {
 
 	if cfg.StartTime.After(cfg.EndTime) {
 		return fmt.Errorf("start_time must be before end_time")
+	}
+
+	if cfg.RealTime && cfg.StartNowMinus > 0 {
+		return fmt.Errorf("start_now_minus cannot be used with real_time: true (results in permanent timestamp lag)")
+	}
+
+	if cfg.RunIndefinitely && (!cfg.EndTime.IsZero() || cfg.EndNowMinus > 0) {
+		return fmt.Errorf("run_indefinitely cannot be combined with end_time or end_now_minus")
 	}
 
 	for _, scn := range cfg.Scenarios {

--- a/metricsgenreceiver/receiver.go
+++ b/metricsgenreceiver/receiver.go
@@ -33,6 +33,7 @@ type MetricsGenReceiver struct {
 	expHistoGen *expohistogen.Generator
 	nextMetrics consumer.Metrics
 	cancel      context.CancelFunc
+	wg          sync.WaitGroup
 	scenarios   []Scenario
 	progress    *MetricsProgress
 }
@@ -80,12 +81,16 @@ func newMetricsGenReceiver(cfg *Config, set receiver.Settings) (*MetricsGenRecei
 		return nil, err
 	}
 
-	nowish := time.Now().Truncate(time.Second)
+	nowish := time.Now()
 	if cfg.StartTime.IsZero() {
 		cfg.StartTime = nowish.Add(-cfg.StartNowMinus)
 	}
 	if cfg.EndTime.IsZero() {
-		cfg.EndTime = nowish.Add(-cfg.EndNowMinus)
+		if cfg.RealTime && cfg.EndNowMinus == 0 {
+			cfg.EndTime = time.Unix(math.MaxInt64/int64(time.Second), 0) // run indefinitely
+		} else {
+			cfg.EndTime = nowish.Add(-cfg.EndNowMinus)
+		}
 	}
 
 	baseRand := rand.New(rand.NewSource(cfg.Seed))
@@ -152,12 +157,14 @@ func newMetricsGenReceiver(cfg *Config, set receiver.Settings) (*MetricsGenRecei
 func (r *MetricsGenReceiver) Start(ctx context.Context, host component.Host) error {
 	ctx, cancel := context.WithCancel(ctx)
 	r.cancel = cancel
+	r.wg.Add(1)
 	go func() {
+		defer r.wg.Done()
 		nextLog := r.progress.start.Add(10 * time.Second)
 		ticker := time.NewTicker(r.cfg.Interval)
 		defer ticker.Stop()
 		currentTime := r.cfg.StartTime
-		for i := 0; currentTime.UnixNano() < r.cfg.EndTime.UnixNano(); i++ {
+		for i := 0; currentTime.Before(r.cfg.EndTime); i++ {
 			if ctx.Err() != nil {
 				return
 			}
@@ -175,7 +182,11 @@ func (r *MetricsGenReceiver) Start(ctx context.Context, host component.Host) err
 			r.applyChurn(i, currentTime)
 
 			if r.cfg.RealTime {
-				<-ticker.C
+				select {
+				case <-ticker.C:
+				case <-ctx.Done():
+					return
+				}
 			}
 			currentTime = currentTime.Add(r.cfg.Interval)
 		}
@@ -341,6 +352,7 @@ func (r *MetricsGenReceiver) Shutdown(_ context.Context) error {
 	if r.cancel != nil {
 		r.cancel()
 	}
+	r.wg.Wait()
 	r.settings.Logger.Info("finished generating metrics",
 		zap.Uint64("datapoints", r.progress.datapoints.Load()),
 		zap.String("duration", r.progress.duration().Round(time.Millisecond).String()),

--- a/metricsgenreceiver/receiver.go
+++ b/metricsgenreceiver/receiver.go
@@ -81,15 +81,15 @@ func newMetricsGenReceiver(cfg *Config, set receiver.Settings) (*MetricsGenRecei
 		return nil, err
 	}
 
-	nowish := time.Now()
+	now := time.Now()
 	if cfg.StartTime.IsZero() {
-		cfg.StartTime = nowish.Add(-cfg.StartNowMinus)
+		cfg.StartTime = now.Add(-cfg.StartNowMinus)
 	}
 	if cfg.EndTime.IsZero() {
-		if cfg.RealTime && cfg.EndNowMinus == 0 {
-			cfg.EndTime = time.Unix(math.MaxInt64/int64(time.Second), 0) // run indefinitely
+		if cfg.RunIndefinitely {
+			cfg.EndTime = time.Unix(math.MaxInt64/int64(time.Second), 0)
 		} else {
-			cfg.EndTime = nowish.Add(-cfg.EndNowMinus)
+			cfg.EndTime = now.Add(-cfg.EndNowMinus)
 		}
 	}
 

--- a/metricsgenreceiver/receiver_test.go
+++ b/metricsgenreceiver/receiver_test.go
@@ -5,12 +5,14 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
 	"github.com/elastic/metricsgenreceiver/metricsgenreceiver/internal/dp"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/consumer"
 	"go.opentelemetry.io/collector/consumer/consumertest"
 	"go.opentelemetry.io/collector/pdata/pcommon"
 	"go.opentelemetry.io/collector/pdata/pmetric"
@@ -455,6 +457,151 @@ func TestInstanceIDWithOffset(t *testing.T) {
 			assert.Equal(t, tc.expectedIDs, ids, "instance IDs should match expected range reflecting the offset")
 		})
 	}
+}
+
+// TestRealtimeDefaultsToRunningIndefinitely verifies that a real_time receiver with no
+// end_time or end_now_minus configured does not exit immediately.
+func TestRealtimeDefaultsToRunningIndefinitely(t *testing.T) {
+	interval := 100 * time.Millisecond
+	sink := new(consumertest.MetricsSink)
+
+	factory := NewFactory()
+	cfg := &Config{
+		Interval: interval,
+		RealTime: true,
+		Seed:     42,
+		Scenarios: []ScenarioCfg{{Path: "testdata/metricstemplate", Scale: 1}},
+	}
+
+	rcv, err := factory.CreateMetrics(context.Background(), receivertest.NewNopSettings(typ), cfg, sink)
+	require.NoError(t, err)
+	err = rcv.Start(context.Background(), nil)
+	require.NoError(t, err)
+
+	// Receiver should keep producing metrics across multiple intervals.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		require.Greater(c, sink.DataPointCount(), 3)
+	}, 2*time.Second, time.Millisecond)
+
+	require.NoError(t, rcv.Shutdown(context.Background()))
+}
+
+// TestRealtimeTimestampsTrackWallClock verifies that metric timestamps stay in sync with
+// wall clock time in realtime mode. Each batch of metrics should have a timestamp close
+// to the wall clock time at which it was produced.
+func TestRealtimeTimestampsTrackWallClock(t *testing.T) {
+	const (
+		interval  = 200 * time.Millisecond
+		batches   = 5
+		tolerance = interval
+	)
+
+	type observation struct {
+		wallClock       time.Time
+		metricTimestamp time.Time
+	}
+	var (
+		mu   sync.Mutex
+		obs  []observation
+	)
+
+	consumer := &timestampRecordingConsumer{
+		onConsume: func(md pmetric.Metrics) {
+			wall := time.Now()
+			var metricTs time.Time
+			dp.ForEachDataPoint(&md, func(_ pcommon.Resource, _ pcommon.InstrumentationScope, _ pmetric.Metric, d dp.DataPoint) {
+				if metricTs.IsZero() {
+					metricTs = d.Timestamp().AsTime()
+				}
+			})
+			mu.Lock()
+			obs = append(obs, observation{wallClock: wall, metricTimestamp: metricTs})
+			mu.Unlock()
+		},
+	}
+
+	factory := NewFactory()
+	cfg := &Config{
+		Interval: interval,
+		RealTime: true,
+		Seed:     42,
+		Scenarios: []ScenarioCfg{{Path: "testdata/metricstemplate", Scale: 1}},
+	}
+
+	rcv, err := factory.CreateMetrics(context.Background(), receivertest.NewNopSettings(typ), cfg, consumer)
+	require.NoError(t, err)
+	require.NoError(t, rcv.Start(context.Background(), nil))
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		mu.Lock()
+		defer mu.Unlock()
+		require.GreaterOrEqual(c, len(obs), batches)
+	}, 5*time.Second, time.Millisecond)
+
+	require.NoError(t, rcv.Shutdown(context.Background()))
+
+	mu.Lock()
+	defer mu.Unlock()
+	for i, o := range obs[:batches] {
+		diff := o.wallClock.Sub(o.metricTimestamp)
+		if diff < 0 {
+			diff = -diff
+		}
+		assert.LessOrEqualf(t, diff, tolerance,
+			"batch %d: metric timestamp %v is %v away from wall clock %v",
+			i, o.metricTimestamp, diff, o.wallClock)
+	}
+}
+
+type timestampRecordingConsumer struct {
+	onConsume func(pmetric.Metrics)
+}
+
+func (c *timestampRecordingConsumer) ConsumeMetrics(_ context.Context, md pmetric.Metrics) error {
+	c.onConsume(md)
+	return nil
+}
+
+func (c *timestampRecordingConsumer) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{}
+}
+
+// TestRealtimeShutdownCompletesPromptly verifies that Shutdown unblocks the goroutine
+// immediately via context cancellation rather than waiting for the next ticker tick.
+// Without the select on ctx.Done() the goroutine stays blocked on <-ticker.C for up
+// to one full interval after Shutdown is called, causing the receiver to stall.
+func TestRealtimeShutdownCompletesPromptly(t *testing.T) {
+	interval := 500 * time.Millisecond
+	sink := new(consumertest.MetricsSink)
+
+	factory := NewFactory()
+	now := time.Now()
+	cfg := &Config{
+		StartTime: now,
+		EndTime:   now.Add(10 * time.Minute),
+		Interval:  interval,
+		RealTime:  true,
+		Seed:      42,
+		Scenarios: []ScenarioCfg{{Path: "testdata/metricstemplate", Scale: 1}},
+	}
+
+	rcv, err := factory.CreateMetrics(context.Background(), receivertest.NewNopSettings(typ), cfg, sink)
+	require.NoError(t, err)
+	err = rcv.Start(context.Background(), nil)
+	require.NoError(t, err)
+
+	// Wait until the first batch is produced; the goroutine is now blocked on ticker.C.
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		require.Greater(c, sink.DataPointCount(), 0)
+	}, interval*3, time.Millisecond)
+
+	// Shutdown must complete well within one interval.
+	// Without the ctx.Done() select branch, Shutdown blocks until the next tick fires
+	// (up to `interval` away), causing a stall when multiple receivers are running.
+	shutdownStart := time.Now()
+	require.NoError(t, rcv.Shutdown(context.Background()))
+	require.Less(t, time.Since(shutdownStart), interval/2,
+		"Shutdown stalled - goroutine was not unblocked by context cancellation")
 }
 
 func collectHostNames(allMetrics []pmetric.Metrics) []string {

--- a/metricsgenreceiver/receiver_test.go
+++ b/metricsgenreceiver/receiver_test.go
@@ -459,18 +459,19 @@ func TestInstanceIDWithOffset(t *testing.T) {
 	}
 }
 
-// TestRealtimeDefaultsToRunningIndefinitely verifies that a real_time receiver with no
-// end_time or end_now_minus configured does not exit immediately.
-func TestRealtimeDefaultsToRunningIndefinitely(t *testing.T) {
+// TestRunIndefinitely verifies that a receiver with run_indefinitely set does not exit
+// immediately but keeps producing metrics across multiple intervals.
+func TestRunIndefinitely(t *testing.T) {
 	interval := 100 * time.Millisecond
 	sink := new(consumertest.MetricsSink)
 
 	factory := NewFactory()
 	cfg := &Config{
-		Interval: interval,
-		RealTime: true,
-		Seed:     42,
-		Scenarios: []ScenarioCfg{{Path: "testdata/metricstemplate", Scale: 1}},
+		Interval:        interval,
+		RealTime:        true,
+		RunIndefinitely: true,
+		Seed:            42,
+		Scenarios:       []ScenarioCfg{{Path: "testdata/metricstemplate", Scale: 1}},
 	}
 
 	rcv, err := factory.CreateMetrics(context.Background(), receivertest.NewNopSettings(typ), cfg, sink)
@@ -522,10 +523,11 @@ func TestRealtimeTimestampsTrackWallClock(t *testing.T) {
 
 	factory := NewFactory()
 	cfg := &Config{
-		Interval: interval,
-		RealTime: true,
-		Seed:     42,
-		Scenarios: []ScenarioCfg{{Path: "testdata/metricstemplate", Scale: 1}},
+		Interval:        interval,
+		RealTime:        true,
+		RunIndefinitely: true,
+		Seed:            42,
+		Scenarios:       []ScenarioCfg{{Path: "testdata/metricstemplate", Scale: 1}},
 	}
 
 	rcv, err := factory.CreateMetrics(context.Background(), receivertest.NewNopSettings(typ), cfg, consumer)


### PR DESCRIPTION
- Remove `Truncate(time.Second)` from `nowish` so real-time timestamps are not systematically up to 1s behind wall clock
- Add `run_indefinitely` flag to explicitly control whether the receiver runs forever, decoupling duration from pacing (`real_time`). Replaces the implicit behaviour where `real_time: true` with no `end_time`/`end_now_minus` would run indefinitely. **Breaking change**: configs relying on that implicit behaviour must add `run_indefinitely: true`.
- Add validation error when `start_now_minus` is used with `real_time: true` — this combination results in a permanent timestamp lag with no way to recover.
- Use `currentTime.Before(EndTime)` in the loop condition to avoid int64 overflow when `EndTime` is set to a far-future value
- Update README with new flag documentation and a real-time indefinite example config
- Update tests to use explicit `run_indefinitely: true`