### PR TITLE
fix(hostmetrics): correct float precision in template

### DIFF
--- a/metricsgenreceiver/internal/metricstmpl/builtin/hostmetrics.json
+++ b/metricsgenreceiver/internal/metricstmpl/builtin/hostmetrics.json
@@ -1358,7 +1358,7 @@
                     ],
                     "startTimeUnixNano": "1734346477000000000",
                     "timeUnixNano": "1734355528689057549",
-                    "asDouble": 0.12862568203441407
+                    "asDouble": 0.128625682
                   },
                   {
                     "attributes": [
@@ -1371,7 +1371,7 @@
                     ],
                     "startTimeUnixNano": "1734346477000000000",
                     "timeUnixNano": "1734355528689057549",
-                    "asDouble": 0.4894956272333089
+                    "asDouble": 0.4894956272
                   },
                   {
                     "attributes": [
@@ -1384,7 +1384,7 @@
                     ],
                     "startTimeUnixNano": "1734346477000000000",
                     "timeUnixNano": "1734355528689057549",
-                    "asDouble": 0.015693495174364445
+                    "asDouble": 0.01569349517
                   },
                   {
                     "attributes": [
@@ -1397,7 +1397,7 @@
                     ],
                     "startTimeUnixNano": "1734346477000000000",
                     "timeUnixNano": "1734355528689057549",
-                    "asDouble": 0.36618519555791257
+                    "asDouble": 0.3661851956
                   },
                   {
                     "attributes": [
@@ -1410,7 +1410,7 @@
                     ],
                     "startTimeUnixNano": "1734346477000000000",
                     "timeUnixNano": "1734355528689057549",
-                    "asDouble": 0.014319991578228131
+                    "asDouble": 0.01431999158
                   },
                   {
                     "attributes": [
@@ -1423,7 +1423,7 @@
                     ],
                     "startTimeUnixNano": "1734346477000000000",
                     "timeUnixNano": "1734355528689057549",
-                    "asDouble": 0.008484339278230316
+                    "asDouble": 0.008484339278
                   }
                 ]
               }
@@ -2214,7 +2214,7 @@
                   {
                     "startTimeUnixNano": "1734346477000000000",
                     "timeUnixNano": "1734355528689759382",
-                    "asDouble": 0
+                    "asDouble": 0.02
                   }
                 ]
               }
@@ -2228,7 +2228,7 @@
                   {
                     "startTimeUnixNano": "1734346477000000000",
                     "timeUnixNano": "1734355528689759382",
-                    "asDouble": 0
+                    "asDouble": 0.01
                   }
                 ]
               }
@@ -2242,7 +2242,7 @@
                   {
                     "startTimeUnixNano": "1734346477000000000",
                     "timeUnixNano": "1734355528689759382",
-                    "asDouble": 0
+                    "asDouble": 0.02
                   }
                 ]
               }


### PR DESCRIPTION
## Summary

Fixes float precision in the `hostmetrics.json` template for `system.memory.utilization` and `system.cpu.load_average.*` metrics.

The template was captured from a real OTel collector that had upstream precision bugs ([opentelemetry-collector-contrib#46141](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46141), [opentelemetry-collector-contrib#46177](https://github.com/open-telemetry/opentelemetry-collector-contrib/issues/46177)). This caused the template to bake in full float64 precision values (17+ decimal places), which in turn caused `InferPrecision` ([#34](https://github.com/elastic/metricsgenreceiver/pull/34)) to infer an effectively unlimited precision target for these metrics.

### Changes

**`system.memory.utilization`** (6 data points): rounded from 17-18 decimal places to 10 significant digits, matching the precision that the upstream fix ([opentelemetry-collector-contrib#46153](https://github.com/open-telemetry/opentelemetry-collector-contrib/pull/46153)) would produce on a typical 32 GB AWS host (e.g., `c6id.4xlarge`).

The upstream fix computes precision as `floor(log10(max(numerator, denominator))) + 1` significant digits. For a 32 GB host with ~34 billion bytes of total memory, this gives ~10-11 significant digits.

| Before | After |
|--------|-------|
| `0.12862568203441407` | `0.128625682` |
| `0.4894956272333089` | `0.4894956272` |
| `0.015693495174364445` | `0.01569349517` |
| `0.36618519555791257` | `0.3661851956` |
| `0.014319991578228131` | `0.01431999158` |
| `0.008484339278230316` | `0.008484339278` |

**`system.cpu.load_average.*`** (3 data points): replaced `0` with realistic non-zero values so `InferPrecision` can infer a 2-decimal target instead of skipping them. The kernel's `/proc/loadavg` outputs load averages with 2 decimal places, so 2 decimals is the correct precision.

| Metric | Before | After |
|--------|--------|-------|
| `system.cpu.load_average.1m` | `0` | `0.01` |
| `system.cpu.load_average.5m` | `0` | `0.02` |
| `system.cpu.load_average.15m` | `0` | `0.02` |