### PR TITLE
feat(generation-hints): add optional metric evolution hints

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,6 +10,11 @@ Common commands:
 make test
 ```
 
+## Core Design Principles
+
+- Keep memory usage bounded by advancing shared templates rather than tracking per-instance or per-time-series state in memory.
+- Keep scenario authoring simple by letting contributors start from the output of an actual Collector execution instead of requiring per-metric code or configuration. Optional generation hints can add more realism when needed.
+
 Built-in scenarios live under `metricsgenreceiver/internal/metricstmpl/builtin/`.
 
 ## Built-in Scenario Guidelines
@@ -44,7 +49,14 @@ When adding or updating a scenario:
    - Prefer fixing bad seeds over adding exceptions.
    - If an all-zero double-valued family is still the most realistic choice, keep the exception narrow and document why in tests.
 
-6. Update the surrounding repo state with the scenario.
+6. Use generation hints only when the default evolution is not realistic enough.
+   - Declare a hint inline in the template by adding a `metricsgen.hint.class` entry to a metric's `metadata` block. The value is the string form of a hint class (e.g. `steady_counter`). The receiver reads and strips this metadata at startup so it does not leak into emitted data.
+   - Hints are not required and do not change the metric schema or the seeded values.
+   - Hints only affect how metric families evolve over time during synthetic generation.
+   - Keep hints narrow and intentional. Add them for families whose behavior materially affects realism or compression.
+   - For the supported hint classes and their intended behavior, see `metricsgenreceiver/internal/distribution/generation_hints.go`.
+
+7. Update the surrounding repo state with the scenario.
    - Add or update the matching `-resource-attributes` template.
    - Document the built-in in `README.md`.
    - Add or update receiver expectations in `metricsgenreceiver/receiver_test.go`.
@@ -58,4 +70,5 @@ Before merging a built-in scenario change, verify:
 - The scenario is representative of a typical environment for its source.
 - Important double-valued metrics have realistic non-zero seed values and decimal precision.
 - Zero-heavy metrics are zero for a good reason.
+- Any generation hints are narrow, understandable, and describe real behavior rather than compensating for bad seeds or violating the project's bounded-memory design principles.
 - Any allowlist entry for an all-zero double-valued family is narrow and justified.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -51,6 +51,8 @@ When adding or updating a scenario:
 
 6. Use generation hints only when the default evolution is not realistic enough.
    - Declare a hint inline in the template by adding a `metricsgen.hint.class` entry to a metric's `metadata` block. The value is the string form of a hint class (e.g. `steady_counter`). The receiver reads and strips this metadata at startup so it does not leak into emitted data.
+   - Hints are supported only on number metrics (`Gauge` and `Sum`).
+   - Hints are enforced per metric family within a scenario: if the same metric name appears multiple times, every occurrence must declare the same hint class or none of them may declare a hint.
    - Hints are not required and do not change the metric schema or the seeded values.
    - Hints only affect how metric families evolve over time during synthetic generation.
    - Keep hints narrow and intentional. Add them for families whose behavior materially affects realism or compression.

--- a/README.md
+++ b/README.md
@@ -129,8 +129,8 @@ receivers:
       Expects a `<path>.json` or `<path>.yaml` and a `<path>-resource-attributes.json` or `<path>-resource-attributes.yaml` file.
       The `<path>.json`/`<path>.yaml` file contains a single batch of resource metrics in JSON or YAML format, as produced by the `fileexporter`.
       The `<path>-resource-attributes.json`/`<path>-resource-attributes.yaml` file contains the resource attributes template.
-      Optional generation hints can be declared inline on a metric by adding a `metricsgen.hint.class` entry to its `metadata` block. Supported classes are `stable_binary`, `current_count`, `slow_gauge`, `steady_counter`, `sparse_counter`, `clock`, and `constant`.
-      These hints only affect how values evolve over time during synthetic generation. The receiver strips the hint metadata at startup so it does not leak into emitted data.
+      Optional generation hints can be declared inline on a number metric (`Gauge` or `Sum`) by adding a `metricsgen.hint.class` entry to its `metadata` block. Supported classes are `stable_binary`, `current_count`, `slow_gauge`, `steady_counter`, `sparse_counter`, `clock`, and `constant`.
+      These hints only affect how values evolve over time during synthetic generation. The receiver strips the hint metadata at startup so it does not leak into emitted data. Hints are enforced per metric name within a scenario: if the same metric name appears multiple times, every occurrence must declare the same hint class or none of them may declare a hint.
       The resource attributes template is used to simulate the individual instances.
       These resource attributes are injected into all resource metrics for which a matching resource attribute key exists.
       Supported placeholders:

--- a/README.md
+++ b/README.md
@@ -127,11 +127,10 @@ receivers:
       * `builtin/node_exporter`: simulates a typical small Linux VM scraped by Prometheus `node_exporter` while keeping Prometheus metric names and target identity keys like `job` and `instance`.
     * Custom scenarios:
       Expects a `<path>.json` or `<path>.yaml` and a `<path>-resource-attributes.json` or `<path>-resource-attributes.yaml` file.
-      Optionally, a scenario can also include a `<path>-generation-hints.json` or `<path>-generation-hints.yaml` file.
       The `<path>.json`/`<path>.yaml` file contains a single batch of resource metrics in JSON or YAML format, as produced by the `fileexporter`.
       The `<path>-resource-attributes.json`/`<path>-resource-attributes.yaml` file contains the resource attributes template.
-      The optional generation hints file classifies metric families such as `binary_state`, `current_count`, `slow_gauge`, `steady_counter`, `sparse_counter`, `clock`, or `constant` to make synthetic updates more realistic.
-      These hints only affect how values evolve over time.
+      Optional generation hints can be declared inline on a metric by adding a `metricsgen.hint.class` entry to its `metadata` block. Supported classes are `stable_binary`, `current_count`, `slow_gauge`, `steady_counter`, `sparse_counter`, `clock`, and `constant`.
+      These hints only affect how values evolve over time during synthetic generation. The receiver strips the hint metadata at startup so it does not leak into emitted data.
       The resource attributes template is used to simulate the individual instances.
       These resource attributes are injected into all resource metrics for which a matching resource attribute key exists.
       Supported placeholders:

--- a/metricsgenreceiver/internal/distribution/distribution.go
+++ b/metricsgenreceiver/internal/distribution/distribution.go
@@ -5,6 +5,7 @@ import (
 	"math/rand"
 	"strconv"
 	"strings"
+	"time"
 
 	"github.com/elastic/metricsgenreceiver/metricsgenreceiver/internal/dp"
 	"github.com/elastic/metricsgenreceiver/metricsgenreceiver/internal/expohistogen"
@@ -22,6 +23,12 @@ type DistributionCfg struct {
 	MedianMonotonicSum uint    `mapstructure:"median_monotonic_sum"`
 	StdDevGaugePct     float64 `mapstructure:"std_dev_gauge_pct"`
 	StdDev             float64 `mapstructure:"std_dev"`
+}
+
+type AdvanceOptions struct {
+	Hint      *MetricGenerationHint
+	Interval  time.Duration
+	Precision map[string]int
 }
 
 func InferPrecision(metrics *pmetric.Metrics) map[string]int {
@@ -57,10 +64,14 @@ func roundToPrecision(v float64, decimals int) float64 {
 	return math.Round(v*mul) / mul
 }
 
-func AdvanceDataPoint(dp dp.DataPoint, r *rand.Rand, m pmetric.Metric, dist DistributionCfg, expHistoGen *expohistogen.Generator, precision map[string]int) {
+func AdvanceDataPoint(dp dp.DataPoint, r *rand.Rand, m pmetric.Metric, dist DistributionCfg, expHistoGen *expohistogen.Generator, opts AdvanceOptions) {
 
 	switch v := dp.(type) {
 	case pmetric.NumberDataPoint:
+		if opts.Hint != nil {
+			opts.Hint.AdvanceNumberDataPoint(v, r, m, dist, opts)
+			return
+		}
 		switch v.ValueType() {
 		case pmetric.NumberDataPointValueTypeDouble:
 			value := v.DoubleValue()
@@ -81,7 +92,7 @@ func AdvanceDataPoint(dp dp.DataPoint, r *rand.Rand, m pmetric.Metric, dist Dist
 			} else {
 				value = advanceFloat(r, m, value, dist)
 			}
-			if p, ok := precision[m.Name()]; ok {
+			if p, ok := opts.Precision[m.Name()]; ok {
 				value = roundToPrecision(value, p)
 			}
 			v.SetDoubleValue(value)

--- a/metricsgenreceiver/internal/distribution/distribution_test.go
+++ b/metricsgenreceiver/internal/distribution/distribution_test.go
@@ -3,6 +3,7 @@ package distribution
 import (
 	"math/rand"
 	"testing"
+	"time"
 
 	"github.com/elastic/metricsgenreceiver/metricsgenreceiver/internal/dp"
 	"github.com/elastic/metricsgenreceiver/metricsgenreceiver/internal/expohistogen"
@@ -154,7 +155,7 @@ func TestAdvanceDataPoint(t *testing.T) {
 		initialCount := dp.Count()
 
 		// Advance the exponential histogram
-		AdvanceDataPoint(dp, r, metric, DefaultDistribution, expHistoGen, nil)
+		AdvanceDataPoint(dp, r, metric, DefaultDistribution, expHistoGen, AdvanceOptions{})
 
 		// Verify the exponential histogram was generated from the template
 		assert.Greater(t, dp.Count(), uint64(0), "count should be positive")
@@ -283,7 +284,7 @@ func TestAdvanceDataPointWithPrecision(t *testing.T) {
 
 	precision := map[string]int{"system.cpu.time": 2}
 	for i := 0; i < 100; i++ {
-		AdvanceDataPoint(d, rng, metric, DefaultDistribution, nil, precision)
+		AdvanceDataPoint(d, rng, metric, DefaultDistribution, nil, AdvanceOptions{Precision: precision})
 		assert.Equal(t, roundToPrecision(d.DoubleValue(), 2), d.DoubleValue())
 	}
 }
@@ -300,13 +301,161 @@ func TestAdvanceDataPointWithZeroPrecision(t *testing.T) {
 
 	precision := map[string]int{"system.fs.inodes.usage": 0}
 	for i := 0; i < 100; i++ {
-		AdvanceDataPoint(d, rng, metric, DefaultDistribution, nil, precision)
+		AdvanceDataPoint(d, rng, metric, DefaultDistribution, nil, AdvanceOptions{Precision: precision})
 		assert.Equal(t, roundToPrecision(d.DoubleValue(), 0), d.DoubleValue())
 	}
 }
 
+func TestAdvanceDataPointWithGenerationHints(t *testing.T) {
+	t.Run("constant", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(42))
+		metric := pmetric.NewMetric()
+		metric.SetName("test.constant")
+		metric.SetEmptyGauge()
+		dp := metric.Gauge().DataPoints().AppendEmpty()
+		dp.SetIntValue(10)
+
+		opts := AdvanceOptions{
+			Hint: &MetricGenerationHint{Class: GenerationHintConstant},
+		}
+		for range 100 {
+			AdvanceDataPoint(dp, rng, metric, DefaultDistribution, nil, opts)
+			assert.Equal(t, int64(10), dp.IntValue())
+		}
+	})
+
+	t.Run("stable binary normalizes seed and never flips", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(42))
+		for _, seed := range []float64{0, 0.3, 0.5, 0.7, 1} {
+			metric := pmetric.NewMetric()
+			metric.SetName("test.stable_binary")
+			metric.SetEmptyGauge()
+			dp := metric.Gauge().DataPoints().AppendEmpty()
+			dp.SetDoubleValue(seed)
+
+			opts := AdvanceOptions{
+				Hint: &MetricGenerationHint{Class: GenerationHintStableBinary},
+			}
+			expected := 0.0
+			if seed >= 0.5 {
+				expected = 1.0
+			}
+			for range 1000 {
+				AdvanceDataPoint(dp, rng, metric, DefaultDistribution, nil, opts)
+				assert.Equal(t, expected, dp.DoubleValue())
+			}
+		}
+	})
+
+	t.Run("current count", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(42))
+		metric := pmetric.NewMetric()
+		metric.SetName("test.current_count")
+		metric.SetEmptyGauge()
+		dp := metric.Gauge().DataPoints().AppendEmpty()
+		dp.SetIntValue(2)
+
+		opts := AdvanceOptions{
+			Hint: &MetricGenerationHint{Class: GenerationHintCurrentCount},
+		}
+		prev := dp.IntValue()
+		for range 100 {
+			AdvanceDataPoint(dp, rng, metric, DefaultDistribution, nil, opts)
+			assert.GreaterOrEqual(t, dp.IntValue(), int64(0))
+			assert.LessOrEqual(t, absInt64(dp.IntValue()-prev), int64(3))
+			prev = dp.IntValue()
+		}
+	})
+
+	t.Run("clock", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(42))
+		metric := pmetric.NewMetric()
+		metric.SetName("test.clock")
+		metric.SetEmptyGauge()
+		dp := metric.Gauge().DataPoints().AppendEmpty()
+		dp.SetDoubleValue(1000)
+
+		opts := AdvanceOptions{
+			Hint:     &MetricGenerationHint{Class: GenerationHintClock},
+			Interval: 30 * time.Second,
+		}
+		for i := 1; i <= 5; i++ {
+			AdvanceDataPoint(dp, rng, metric, DefaultDistribution, nil, opts)
+			assert.Equal(t, 1000+float64(30*i), dp.DoubleValue())
+		}
+	})
+
+	t.Run("steady counter overrides gauge semantics", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(42))
+		metric := pmetric.NewMetric()
+		metric.SetName("test.steady_counter")
+		metric.SetEmptyGauge()
+		dp := metric.Gauge().DataPoints().AppendEmpty()
+		dp.SetIntValue(10)
+
+		opts := AdvanceOptions{
+			Hint: &MetricGenerationHint{Class: GenerationHintSteadyCounter},
+		}
+		prev := dp.IntValue()
+		for range 20 {
+			AdvanceDataPoint(dp, rng, metric, DefaultDistribution, nil, opts)
+			assert.GreaterOrEqual(t, dp.IntValue(), prev)
+			prev = dp.IntValue()
+		}
+	})
+
+	t.Run("sparse counter is mostly flat", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(42))
+		metric := pmetric.NewMetric()
+		metric.SetName("test.sparse_counter")
+		metric.SetEmptyGauge()
+		dp := metric.Gauge().DataPoints().AppendEmpty()
+		dp.SetIntValue(0)
+
+		opts := AdvanceOptions{
+			Hint: &MetricGenerationHint{Class: GenerationHintSparseCounter},
+		}
+		prev := dp.IntValue()
+		unchanged := 0
+		for range 100 {
+			AdvanceDataPoint(dp, rng, metric, DefaultDistribution, nil, opts)
+			assert.GreaterOrEqual(t, dp.IntValue(), prev)
+			if dp.IntValue() == prev {
+				unchanged++
+			}
+			prev = dp.IntValue()
+		}
+		assert.GreaterOrEqual(t, unchanged, 80)
+	})
+
+	t.Run("slow gauge keeps utilization bounded", func(t *testing.T) {
+		rng := rand.New(rand.NewSource(42))
+		metric := pmetric.NewMetric()
+		metric.SetName("system.cpu.utilization")
+		metric.SetEmptyGauge()
+		dp := metric.Gauge().DataPoints().AppendEmpty()
+		dp.SetDoubleValue(0.5)
+
+		opts := AdvanceOptions{
+			Hint: &MetricGenerationHint{Class: GenerationHintSlowGauge},
+		}
+		for range 100 {
+			AdvanceDataPoint(dp, rng, metric, DefaultDistribution, nil, opts)
+			assert.GreaterOrEqual(t, dp.DoubleValue(), 0.0)
+			assert.LessOrEqual(t, dp.DoubleValue(), 1.0)
+		}
+	})
+}
+
 func advanceDataPointNTimes(dp dp.DataPoint, r *rand.Rand, metric pmetric.Metric, n int) {
 	for i := 0; i < n; i++ {
-		AdvanceDataPoint(dp, r, metric, DefaultDistribution, nil, nil)
+		AdvanceDataPoint(dp, r, metric, DefaultDistribution, nil, AdvanceOptions{})
 	}
+}
+
+func absInt64(v int64) int64 {
+	if v < 0 {
+		return -v
+	}
+	return v
 }

--- a/metricsgenreceiver/internal/distribution/generation_hints.go
+++ b/metricsgenreceiver/internal/distribution/generation_hints.go
@@ -1,0 +1,190 @@
+package distribution
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"strings"
+
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+type GenerationHintClass string
+
+const (
+	// GenerationHintClock advances a time-like metric deterministically with the collection interval.
+	// Example: node_time_seconds.
+	GenerationHintClock         GenerationHintClass = "clock"
+	// GenerationHintConstant keeps a metric fixed after its initial seed value.
+	// Examples: node_memory_MemTotal_bytes, node_boot_time_seconds.
+	GenerationHintConstant      GenerationHintClass = "constant"
+	// GenerationHintCurrentCount models a non-negative integer count that changes in small steps.
+	// Examples: system.network.connections, node_sockstat_TCP_inuse.
+	GenerationHintCurrentCount  GenerationHintClass = "current_count"
+	// GenerationHintSlowGauge models a gauge that moves gradually instead of wandering wildly between intervals.
+	// Examples: system.cpu.utilization, system.memory.usage.
+	GenerationHintSlowGauge     GenerationHintClass = "slow_gauge"
+	// GenerationHintSparseCounter models a counter-like series that is flat most intervals and only increases occasionally.
+	// Examples: system.network.errors, node_vmstat_oom_kill.
+	GenerationHintSparseCounter GenerationHintClass = "sparse_counter"
+	// GenerationHintStableBinary keeps a metric strictly at 0 or 1 and never flips after the seed is normalized.
+	// Examples: node_network_up, node_filesystem_readonly.
+	GenerationHintStableBinary  GenerationHintClass = "stable_binary"
+	// GenerationHintSteadyCounter models a counter-like series that increases at a fairly stable rate most intervals.
+	// Examples: system.cpu.time, node_network_receive_bytes_total.
+	GenerationHintSteadyCounter GenerationHintClass = "steady_counter"
+)
+
+// MetricGenerationHint optionally overrides the default evolution model for a metric family.
+type MetricGenerationHint struct {
+	Class GenerationHintClass `json:"class" yaml:"class"`
+}
+
+// GenerationHintStrategy evolves a metric family on the shared template at each interval tick.
+// It is only invoked during the template advance pass, once per data point per interval. The
+// per-instance emission pass does not call Advance — instance-level variation is handled by
+// InstanceVariationStrategy, which layers a deterministic offset or multiplier on top of the
+// value Advance produced.
+//
+// Implementations should be pure functions of the arguments: given the same current value and
+// options, successive calls are expected to produce a well-behaved random walk (or deterministic
+// progression, for clock/constant/stable_binary). They must not keep per-series state, which
+// would violate the project's bounded-memory design principle.
+type GenerationHintStrategy interface {
+	Advance(current float64, rand *rand.Rand, metric pmetric.Metric, dist DistributionCfg, opts AdvanceOptions) float64
+}
+
+var strategies = map[GenerationHintClass]GenerationHintStrategy{
+	GenerationHintClock:         clockStrategy{},
+	GenerationHintConstant:      constantStrategy{},
+	GenerationHintCurrentCount:  currentCountStrategy{},
+	GenerationHintSlowGauge:     slowGaugeStrategy{},
+	GenerationHintSparseCounter: sparseCounterStrategy{},
+	GenerationHintStableBinary:  stableBinaryStrategy{},
+	GenerationHintSteadyCounter: steadyCounterStrategy{},
+}
+
+func (h MetricGenerationHint) Validate(metricName string) error {
+	if h.Class == "" {
+		return fmt.Errorf("metric generation hint for %q is missing a class", metricName)
+	}
+	if _, ok := strategies[h.Class]; !ok {
+		return fmt.Errorf("metric generation hint for %q has unsupported class %q", metricName, h.Class)
+	}
+	return nil
+}
+
+type ScenarioGenerationHints struct {
+	MetricGenerationHints map[string]MetricGenerationHint `json:"metric_generation_hints" yaml:"metric_generation_hints"`
+}
+
+func (h MetricGenerationHint) AdvanceNumberDataPoint(v pmetric.NumberDataPoint, rand *rand.Rand, metric pmetric.Metric, dist DistributionCfg, opts AdvanceOptions) {
+	strategy, ok := strategies[h.Class]
+	if !ok {
+		panic(fmt.Sprintf("unsupported generation hint class %q", h.Class))
+	}
+	current := currentNumberDataPointValue(v)
+	next := strategy.Advance(current, rand, metric, dist, opts)
+
+	switch v.ValueType() {
+	case pmetric.NumberDataPointValueTypeDouble:
+		if p, ok := opts.Precision[metric.Name()]; ok {
+			next = roundToPrecision(next, p)
+		}
+		v.SetDoubleValue(next)
+	case pmetric.NumberDataPointValueTypeInt:
+		v.SetIntValue(int64(math.Max(0, math.Round(next))))
+	}
+}
+
+type clockStrategy struct{}
+
+func (clockStrategy) Advance(current float64, _ *rand.Rand, _ pmetric.Metric, _ DistributionCfg, opts AdvanceOptions) float64 {
+	return current + opts.Interval.Seconds()
+}
+
+type constantStrategy struct{}
+
+func (constantStrategy) Advance(current float64, _ *rand.Rand, _ pmetric.Metric, _ DistributionCfg, _ AdvanceOptions) float64 {
+	return current
+}
+
+type currentCountStrategy struct{}
+
+func (currentCountStrategy) Advance(current float64, rand *rand.Rand, _ pmetric.Metric, _ DistributionCfg, _ AdvanceOptions) float64 {
+	step := 0.0
+	switch p := rand.Float64(); {
+	case p < 0.70:
+		step = 0
+	case p < 0.90:
+		step = signedUnitStep(rand)
+	default:
+		step = 2 * signedUnitStep(rand)
+	}
+	return math.Max(0, current+step)
+}
+
+type slowGaugeStrategy struct{}
+
+func (slowGaugeStrategy) Advance(current float64, rand *rand.Rand, metric pmetric.Metric, dist DistributionCfg, _ AdvanceOptions) float64 {
+	scale := math.Max(math.Abs(current), 1)
+	value := math.Abs(current + rand.NormFloat64()*math.Max(dist.StdDev*0.2, scale*0.005))
+	if strings.HasSuffix(metric.Name(), ".utilization") {
+		value = min(value, 1)
+	}
+	return value
+}
+
+type sparseCounterStrategy struct{}
+
+func (sparseCounterStrategy) Advance(current float64, rand *rand.Rand, metric pmetric.Metric, dist DistributionCfg, _ AdvanceOptions) float64 {
+	delta := 0.0
+	if rand.Float64() < 0.05 {
+		delta = math.Abs(rand.NormFloat64() * dist.StdDev)
+		if delta == 0 {
+			delta = 1
+		}
+	}
+	return applyCounterDelta(metric, current, delta)
+}
+
+type stableBinaryStrategy struct{}
+
+func (stableBinaryStrategy) Advance(current float64, _ *rand.Rand, _ pmetric.Metric, _ DistributionCfg, _ AdvanceOptions) float64 {
+	if math.Round(current) < 0.5 {
+		return 0
+	}
+	return 1
+}
+
+type steadyCounterStrategy struct{}
+
+func (steadyCounterStrategy) Advance(current float64, rand *rand.Rand, metric pmetric.Metric, dist DistributionCfg, _ AdvanceOptions) float64 {
+	delta := math.Abs(rand.NormFloat64()*dist.StdDev + float64(dist.MedianMonotonicSum))
+	return applyCounterDelta(metric, current, delta)
+}
+
+func currentNumberDataPointValue(v pmetric.NumberDataPoint) float64 {
+	switch v.ValueType() {
+	case pmetric.NumberDataPointValueTypeDouble:
+		return v.DoubleValue()
+	case pmetric.NumberDataPointValueTypeInt:
+		return float64(v.IntValue())
+	default:
+		return 0
+	}
+}
+
+func applyCounterDelta(metric pmetric.Metric, current float64, delta float64) float64 {
+	if isDelta(&metric) {
+		return delta
+	}
+	return current + delta
+}
+
+func signedUnitStep(rand *rand.Rand) float64 {
+	if rand.Float64() < 0.5 {
+		return -1
+	}
+	return 1
+}

--- a/metricsgenreceiver/internal/metricstmpl/generation_hints.go
+++ b/metricsgenreceiver/internal/metricstmpl/generation_hints.go
@@ -17,16 +17,35 @@ import (
 // for any metric that does not declare one.
 const GenerationHintMetadataKey = "metricsgen.hint.class"
 
+type metricHintConsistency struct {
+	hintClass distribution.GenerationHintClass
+	hasHint   bool
+	seen      bool
+}
+
 // ExtractGenerationHints reads GenerationHintMetadataKey from each metric's metadata, validates
 // the class, strips the key so it does not propagate to emitted data, and returns a
-// metric-name → hint map. If any metric declares an invalid class, all validation errors are
-// joined and returned; the template is not mutated in that case.
+// metric-name -> hint map. Hints are enforced per metric family within a scenario, so every
+// occurrence of the same metric name must either declare the same class or declare no hint at
+// all. If any metric declares an invalid class, all validation errors are joined and returned;
+// the template is not mutated in that case.
 func ExtractGenerationHints(metrics *pmetric.Metrics) (map[string]distribution.MetricGenerationHint, error) {
 	hints := make(map[string]distribution.MetricGenerationHint)
+	consistency := make(map[string]metricHintConsistency)
 	var errs []error
 	dp.ForEachMetric(metrics, func(_ pcommon.Resource, _ pcommon.InstrumentationScope, m pmetric.Metric) {
 		v, ok := m.Metadata().Get(GenerationHintMetadataKey)
+		state := consistency[m.Name()]
 		if !ok {
+			if state.hasHint {
+				errs = append(errs, fmt.Errorf("metric %q must declare %s consistently across all occurrences", m.Name(), GenerationHintMetadataKey))
+			}
+			state.seen = true
+			consistency[m.Name()] = state
+			return
+		}
+		if !supportsGenerationHints(m) {
+			errs = append(errs, fmt.Errorf("metric %q with %s must be a gauge or sum", m.Name(), GenerationHintMetadataKey))
 			return
 		}
 		if v.Type() != pcommon.ValueTypeStr {
@@ -38,6 +57,18 @@ func ExtractGenerationHints(metrics *pmetric.Metrics) (map[string]distribution.M
 			errs = append(errs, err)
 			return
 		}
+		if state.seen && !state.hasHint {
+			errs = append(errs, fmt.Errorf("metric %q must declare %s consistently across all occurrences", m.Name(), GenerationHintMetadataKey))
+			return
+		}
+		if state.hasHint && state.hintClass != hint.Class {
+			errs = append(errs, fmt.Errorf("metric %q must use the same %s across all occurrences", m.Name(), GenerationHintMetadataKey))
+			return
+		}
+		state.seen = true
+		state.hasHint = true
+		state.hintClass = hint.Class
+		consistency[m.Name()] = state
 		hints[m.Name()] = hint
 	})
 	if len(errs) > 0 {
@@ -48,4 +79,8 @@ func ExtractGenerationHints(metrics *pmetric.Metrics) (map[string]distribution.M
 		m.Metadata().Remove(GenerationHintMetadataKey)
 	})
 	return hints, nil
+}
+
+func supportsGenerationHints(m pmetric.Metric) bool {
+	return m.Type() == pmetric.MetricTypeGauge || m.Type() == pmetric.MetricTypeSum
 }

--- a/metricsgenreceiver/internal/metricstmpl/generation_hints.go
+++ b/metricsgenreceiver/internal/metricstmpl/generation_hints.go
@@ -1,0 +1,51 @@
+package metricstmpl
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/elastic/metricsgenreceiver/metricsgenreceiver/internal/distribution"
+	"github.com/elastic/metricsgenreceiver/metricsgenreceiver/internal/dp"
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+// GenerationHintMetadataKey is the per-metric metadata key used to declare a generation hint
+// inline in the template. Values are the string form of a distribution.GenerationHintClass
+// (e.g. "steady_counter"). The receiver reads and validates this key at startup, removes it
+// from the template so it does not leak into emitted data, and falls back to default evolution
+// for any metric that does not declare one.
+const GenerationHintMetadataKey = "metricsgen.hint.class"
+
+// ExtractGenerationHints reads GenerationHintMetadataKey from each metric's metadata, validates
+// the class, strips the key so it does not propagate to emitted data, and returns a
+// metric-name → hint map. If any metric declares an invalid class, all validation errors are
+// joined and returned; the template is not mutated in that case.
+func ExtractGenerationHints(metrics *pmetric.Metrics) (map[string]distribution.MetricGenerationHint, error) {
+	hints := make(map[string]distribution.MetricGenerationHint)
+	var errs []error
+	dp.ForEachMetric(metrics, func(_ pcommon.Resource, _ pcommon.InstrumentationScope, m pmetric.Metric) {
+		v, ok := m.Metadata().Get(GenerationHintMetadataKey)
+		if !ok {
+			return
+		}
+		if v.Type() != pcommon.ValueTypeStr {
+			errs = append(errs, fmt.Errorf("metric %q has non-string %s metadata", m.Name(), GenerationHintMetadataKey))
+			return
+		}
+		hint := distribution.MetricGenerationHint{Class: distribution.GenerationHintClass(v.Str())}
+		if err := hint.Validate(m.Name()); err != nil {
+			errs = append(errs, err)
+			return
+		}
+		hints[m.Name()] = hint
+	})
+	if len(errs) > 0 {
+		return nil, errors.Join(errs...)
+	}
+	// Only strip on success, so the template stays inspectable when reporting validation errors.
+	dp.ForEachMetric(metrics, func(_ pcommon.Resource, _ pcommon.InstrumentationScope, m pmetric.Metric) {
+		m.Metadata().Remove(GenerationHintMetadataKey)
+	})
+	return hints, nil
+}

--- a/metricsgenreceiver/internal/metricstmpl/generation_hints_test.go
+++ b/metricsgenreceiver/internal/metricstmpl/generation_hints_test.go
@@ -10,9 +10,7 @@ import (
 
 func TestExtractGenerationHintsNoMetadataIsNoop(t *testing.T) {
 	metrics := pmetric.NewMetrics()
-	m := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
-	m.SetName("test.metric")
-	m.SetEmptyGauge()
+	appendGaugeMetric(metrics, "test.metric")
 
 	hints, err := ExtractGenerationHints(&metrics)
 	require.NoError(t, err)
@@ -21,9 +19,7 @@ func TestExtractGenerationHintsNoMetadataIsNoop(t *testing.T) {
 
 func TestExtractGenerationHintsReadsAndStripsMetadata(t *testing.T) {
 	metrics := pmetric.NewMetrics()
-	m := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
-	m.SetName("test.metric")
-	m.SetEmptyGauge()
+	m := appendGaugeMetric(metrics, "test.metric")
 	m.Metadata().PutStr(GenerationHintMetadataKey, "slow_gauge")
 	m.Metadata().PutStr("prometheus.type", "gauge")
 
@@ -41,9 +37,7 @@ func TestExtractGenerationHintsReadsAndStripsMetadata(t *testing.T) {
 
 func TestExtractGenerationHintsInvalidClass(t *testing.T) {
 	metrics := pmetric.NewMetrics()
-	m := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
-	m.SetName("test.metric")
-	m.SetEmptyGauge()
+	m := appendGaugeMetric(metrics, "test.metric")
 	m.Metadata().PutStr(GenerationHintMetadataKey, "not_a_real_hint")
 
 	hints, err := ExtractGenerationHints(&metrics)
@@ -60,9 +54,7 @@ func TestExtractGenerationHintsInvalidClass(t *testing.T) {
 
 func TestExtractGenerationHintsMissingClass(t *testing.T) {
 	metrics := pmetric.NewMetrics()
-	m := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
-	m.SetName("test.metric")
-	m.SetEmptyGauge()
+	m := appendGaugeMetric(metrics, "test.metric")
 	m.Metadata().PutStr(GenerationHintMetadataKey, "")
 
 	hints, err := ExtractGenerationHints(&metrics)
@@ -74,13 +66,119 @@ func TestExtractGenerationHintsMissingClass(t *testing.T) {
 
 func TestExtractGenerationHintsNonStringMetadata(t *testing.T) {
 	metrics := pmetric.NewMetrics()
-	m := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
-	m.SetName("test.metric")
-	m.SetEmptyGauge()
+	m := appendGaugeMetric(metrics, "test.metric")
 	m.Metadata().PutInt(GenerationHintMetadataKey, 42)
 
 	hints, err := ExtractGenerationHints(&metrics)
 	require.Error(t, err)
 	assert.Nil(t, hints)
 	assert.Contains(t, err.Error(), "non-string")
+}
+
+func TestExtractGenerationHintsRepeatedMetricNameSameHintIsAllowed(t *testing.T) {
+	metrics := pmetric.NewMetrics()
+	first := appendGaugeMetric(metrics, "test.metric")
+	second := appendGaugeMetric(metrics, "test.metric")
+	first.Metadata().PutStr(GenerationHintMetadataKey, "steady_counter")
+	second.Metadata().PutStr(GenerationHintMetadataKey, "steady_counter")
+
+	hints, err := ExtractGenerationHints(&metrics)
+	require.NoError(t, err)
+	require.Len(t, hints, 1)
+	assert.Equal(t, "steady_counter", string(hints["test.metric"].Class))
+
+	_, firstHasHint := first.Metadata().Get(GenerationHintMetadataKey)
+	_, secondHasHint := second.Metadata().Get(GenerationHintMetadataKey)
+	assert.False(t, firstHasHint)
+	assert.False(t, secondHasHint)
+}
+
+func TestExtractGenerationHintsRepeatedMetricNameDifferentHintFails(t *testing.T) {
+	metrics := pmetric.NewMetrics()
+	first := appendGaugeMetric(metrics, "test.metric")
+	second := appendGaugeMetric(metrics, "test.metric")
+	first.Metadata().PutStr(GenerationHintMetadataKey, "steady_counter")
+	second.Metadata().PutStr(GenerationHintMetadataKey, "slow_gauge")
+
+	hints, err := ExtractGenerationHints(&metrics)
+	require.Error(t, err)
+	assert.Nil(t, hints)
+	assert.Contains(t, err.Error(), "same metricsgen.hint.class across all occurrences")
+
+	v, ok := first.Metadata().Get(GenerationHintMetadataKey)
+	require.True(t, ok)
+	assert.Equal(t, "steady_counter", v.Str())
+}
+
+func TestExtractGenerationHintsRepeatedMetricNameMixedHintPresenceFails(t *testing.T) {
+	metrics := pmetric.NewMetrics()
+	first := appendGaugeMetric(metrics, "test.metric")
+	appendGaugeMetric(metrics, "test.metric")
+	first.Metadata().PutStr(GenerationHintMetadataKey, "steady_counter")
+
+	hints, err := ExtractGenerationHints(&metrics)
+	require.Error(t, err)
+	assert.Nil(t, hints)
+	assert.Contains(t, err.Error(), "declare metricsgen.hint.class consistently across all occurrences")
+}
+
+func TestExtractGenerationHintsRejectsNonNumberMetrics(t *testing.T) {
+	tests := []struct {
+		name   string
+		append func(pmetric.Metrics, string) pmetric.Metric
+	}{
+		{
+			name:   "histogram",
+			append: appendHistogramMetric,
+		},
+		{
+			name:   "exponential histogram",
+			append: appendExponentialHistogramMetric,
+		},
+		{
+			name:   "summary",
+			append: appendSummaryMetric,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			metrics := pmetric.NewMetrics()
+			m := tt.append(metrics, "test.metric")
+			m.Metadata().PutStr(GenerationHintMetadataKey, "constant")
+
+			hints, err := ExtractGenerationHints(&metrics)
+			require.Error(t, err)
+			assert.Nil(t, hints)
+			assert.Contains(t, err.Error(), "must be a gauge or sum")
+		})
+	}
+}
+
+func appendGaugeMetric(metrics pmetric.Metrics, name string) pmetric.Metric {
+	m := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	m.SetName(name)
+	m.SetEmptyGauge()
+	return m
+}
+
+func appendHistogramMetric(metrics pmetric.Metrics, name string) pmetric.Metric {
+	m := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	m.SetName(name)
+	m.SetEmptyHistogram()
+	return m
+}
+
+func appendExponentialHistogramMetric(metrics pmetric.Metrics, name string) pmetric.Metric {
+	m := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	m.SetName(name)
+	m.SetEmptyExponentialHistogram()
+	return m
+}
+
+func appendSummaryMetric(metrics pmetric.Metrics, name string) pmetric.Metric {
+	m := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	m.SetName(name)
+	m.SetEmptySummary()
+	return m
 }

--- a/metricsgenreceiver/internal/metricstmpl/generation_hints_test.go
+++ b/metricsgenreceiver/internal/metricstmpl/generation_hints_test.go
@@ -1,0 +1,86 @@
+package metricstmpl
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+func TestExtractGenerationHintsNoMetadataIsNoop(t *testing.T) {
+	metrics := pmetric.NewMetrics()
+	m := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	m.SetName("test.metric")
+	m.SetEmptyGauge()
+
+	hints, err := ExtractGenerationHints(&metrics)
+	require.NoError(t, err)
+	assert.Empty(t, hints)
+}
+
+func TestExtractGenerationHintsReadsAndStripsMetadata(t *testing.T) {
+	metrics := pmetric.NewMetrics()
+	m := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	m.SetName("test.metric")
+	m.SetEmptyGauge()
+	m.Metadata().PutStr(GenerationHintMetadataKey, "slow_gauge")
+	m.Metadata().PutStr("prometheus.type", "gauge")
+
+	hints, err := ExtractGenerationHints(&metrics)
+	require.NoError(t, err)
+	require.Len(t, hints, 1)
+	assert.Equal(t, "slow_gauge", string(hints["test.metric"].Class))
+
+	// Hint metadata is stripped; unrelated metadata is left alone.
+	_, hasHint := m.Metadata().Get(GenerationHintMetadataKey)
+	assert.False(t, hasHint)
+	_, hasPromType := m.Metadata().Get("prometheus.type")
+	assert.True(t, hasPromType)
+}
+
+func TestExtractGenerationHintsInvalidClass(t *testing.T) {
+	metrics := pmetric.NewMetrics()
+	m := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	m.SetName("test.metric")
+	m.SetEmptyGauge()
+	m.Metadata().PutStr(GenerationHintMetadataKey, "not_a_real_hint")
+
+	hints, err := ExtractGenerationHints(&metrics)
+	require.Error(t, err)
+	assert.Nil(t, hints)
+	assert.Contains(t, err.Error(), "unsupported class")
+	assert.Contains(t, err.Error(), "test.metric")
+
+	// Metadata is not stripped on error so the failure stays inspectable.
+	v, ok := m.Metadata().Get(GenerationHintMetadataKey)
+	require.True(t, ok)
+	assert.Equal(t, "not_a_real_hint", v.Str())
+}
+
+func TestExtractGenerationHintsMissingClass(t *testing.T) {
+	metrics := pmetric.NewMetrics()
+	m := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	m.SetName("test.metric")
+	m.SetEmptyGauge()
+	m.Metadata().PutStr(GenerationHintMetadataKey, "")
+
+	hints, err := ExtractGenerationHints(&metrics)
+	require.Error(t, err)
+	assert.Nil(t, hints)
+	assert.Contains(t, err.Error(), "missing a class")
+	assert.Contains(t, err.Error(), "test.metric")
+}
+
+func TestExtractGenerationHintsNonStringMetadata(t *testing.T) {
+	metrics := pmetric.NewMetrics()
+	m := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty().Metrics().AppendEmpty()
+	m.SetName("test.metric")
+	m.SetEmptyGauge()
+	m.Metadata().PutInt(GenerationHintMetadataKey, 42)
+
+	hints, err := ExtractGenerationHints(&metrics)
+	require.Error(t, err)
+	assert.Nil(t, hints)
+	assert.Contains(t, err.Error(), "non-string")
+}

--- a/metricsgenreceiver/receiver.go
+++ b/metricsgenreceiver/receiver.go
@@ -44,6 +44,7 @@ type Scenario struct {
 	resourceAttributesTemplate pcommon.Resource
 	resources                  []pcommon.Resource
 	precision                  map[string]int
+	generationHints            map[string]distribution.MetricGenerationHint
 }
 
 type MetricsProgress struct {
@@ -106,6 +107,10 @@ func newMetricsGenReceiver(cfg *Config, set receiver.Settings) (*MetricsGenRecei
 		if err != nil {
 			return nil, err
 		}
+		generationHints, err := metricstmpl.ExtractGenerationHints(&metrics)
+		if err != nil {
+			return nil, err
+		}
 
 		if scn.ForceExponentialHistograms() {
 			dp.ForEachMetric(&metrics, func(res pcommon.Resource, is pcommon.InstrumentationScope, m pmetric.Metric) {
@@ -140,6 +145,7 @@ func newMetricsGenReceiver(cfg *Config, set receiver.Settings) (*MetricsGenRecei
 			metricsTemplate: &metrics,
 			resources:       resources,
 			precision:       distribution.InferPrecision(&metrics),
+			generationHints: generationHints,
 		})
 	}
 
@@ -287,8 +293,15 @@ func (r *MetricsGenReceiver) produceMetrics(ctx context.Context, currentTime tim
 		// we don't keep track of the data points for each instance individually to reduce memory pressure
 		// we still advance the metrics template have a new baseline that's used when simulating the metrics for each individual instance
 		// this makes sure counters are increasing over time
-		dp.ForEachDataPoint(scn.metricsTemplate, func(res pcommon.Resource, is pcommon.InstrumentationScope, m pmetric.Metric, dp dp.DataPoint) {
-			distribution.AdvanceDataPoint(dp, r.baseRand, m, r.cfg.Distribution, r.expHistoGen, scn.precision)
+		dp.ForEachDataPoint(scn.metricsTemplate, func(res pcommon.Resource, is pcommon.InstrumentationScope, m pmetric.Metric, dataPoint dp.DataPoint) {
+			opts := distribution.AdvanceOptions{
+				Interval:  r.cfg.Interval,
+				Precision: scn.precision,
+			}
+			if hint, ok := scn.generationHints[m.Name()]; ok {
+				opts.Hint = &hint
+			}
+			distribution.AdvanceDataPoint(dataPoint, r.baseRand, m, r.cfg.Distribution, r.expHistoGen, opts)
 		})
 		if scn.config.Concurrency == 0 {
 			for i := range scn.config.Scale {
@@ -327,9 +340,13 @@ func (r *MetricsGenReceiver) produceMetricsForInstance(ctx context.Context, rng 
 
 	instanceTime := addJitter(currentTime, r.cfg.IntervalJitterStdDev, r.cfg.Interval, rng)
 
-	dp.ForEachDataPoint(&metrics, func(res pcommon.Resource, is pcommon.InstrumentationScope, m pmetric.Metric, dp dp.DataPoint) {
-		distribution.AdvanceDataPoint(dp, rng, m, r.cfg.Distribution, r.expHistoGen, scn.precision)
-		dp.SetTimestamp(pcommon.NewTimestampFromTime(instanceTime))
+	dp.ForEachDataPoint(&metrics, func(res pcommon.Resource, is pcommon.InstrumentationScope, m pmetric.Metric, dataPoint dp.DataPoint) {
+		if _, ok := scn.generationHints[m.Name()]; !ok {
+			distribution.AdvanceDataPoint(dataPoint, rng, m, r.cfg.Distribution, r.expHistoGen, distribution.AdvanceOptions{
+				Precision: scn.precision,
+			})
+		}
+		dataPoint.SetTimestamp(pcommon.NewTimestampFromTime(instanceTime))
 	})
 	dataPoints := metrics.DataPointCount()
 	err := r.nextMetrics.ConsumeMetrics(ctx, metrics)

--- a/metricsgenreceiver/receiver_test.go
+++ b/metricsgenreceiver/receiver_test.go
@@ -634,3 +634,107 @@ func collectHostNames(allMetrics []pmetric.Metrics) []string {
 
 	return hosts
 }
+
+func TestReceiverAppliesGenerationHints(t *testing.T) {
+	sink := new(consumertest.MetricsSink)
+
+	factory := NewFactory()
+	cfg := testdataConfigYamlAsMap()
+	cfg.Scenarios[0].Path = "testdata/generation-hints-template"
+	cfg.Scenarios[0].Scale = 2
+
+	rcv, err := factory.CreateMetrics(context.Background(), receivertest.NewNopSettings(typ), cfg, sink)
+	require.NoError(t, err)
+	err = rcv.Start(context.Background(), nil)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		require.Equal(c, 5*2*cfg.Scenarios[0].Scale, sink.DataPointCount())
+	}, 2*time.Second, time.Millisecond)
+	require.NoError(t, rcv.Shutdown(context.Background()))
+
+	allMetrics := sink.AllMetrics()
+	require.Len(t, allMetrics, 4)
+
+	firstIntervalHost0 := allMetrics[0]
+	firstIntervalHost1 := allMetrics[1]
+	secondIntervalHost0 := allMetrics[2]
+	secondIntervalHost1 := allMetrics[3]
+
+	// constant: identical across hosts and intervals.
+	assert.Equal(t, metricIntValue(t, firstIntervalHost0, "test.constant"), metricIntValue(t, secondIntervalHost0, "test.constant"))
+	assert.Equal(t, metricIntValue(t, firstIntervalHost0, "test.constant"), metricIntValue(t, firstIntervalHost1, "test.constant"))
+
+	// clock: identical across hosts, advances by the collection interval.
+	assert.Equal(t, metricDoubleValue(t, firstIntervalHost0, "test.clock"), metricDoubleValue(t, firstIntervalHost1, "test.clock"))
+	assert.Equal(t, metricDoubleValue(t, secondIntervalHost0, "test.clock"), metricDoubleValue(t, secondIntervalHost1, "test.clock"))
+	assert.Equal(t, 30.0, metricDoubleValue(t, secondIntervalHost0, "test.clock")-metricDoubleValue(t, firstIntervalHost0, "test.clock"))
+
+	// stable_binary: identical across hosts and intervals, normalized to 0 or 1.
+	assert.Equal(t, int64(1), metricIntValue(t, firstIntervalHost0, "test.stable_binary"))
+	assert.Equal(t, int64(1), metricIntValue(t, firstIntervalHost1, "test.stable_binary"))
+	assert.Equal(t, int64(1), metricIntValue(t, secondIntervalHost0, "test.stable_binary"))
+	assert.Equal(t, int64(1), metricIntValue(t, secondIntervalHost1, "test.stable_binary"))
+
+	// current_count: moves in small integer steps. With hints declared, instances share the same template-advanced value.
+	firstCount := metricIntValue(t, firstIntervalHost0, "test.current_count")
+	secondCount := metricIntValue(t, secondIntervalHost0, "test.current_count")
+	assert.Equal(t, firstCount, metricIntValue(t, firstIntervalHost1, "test.current_count"))
+	assert.Equal(t, secondCount, metricIntValue(t, secondIntervalHost1, "test.current_count"))
+	assert.GreaterOrEqual(t, firstCount, int64(0))
+	assert.GreaterOrEqual(t, secondCount, int64(0))
+	assert.LessOrEqual(t, absInt64(secondCount-firstCount), int64(3))
+}
+
+func metricIntValue(t *testing.T, metrics pmetric.Metrics, metricName string) int64 {
+	t.Helper()
+
+	var value int64
+	found := false
+	dp.ForEachMetric(&metrics, func(res pcommon.Resource, is pcommon.InstrumentationScope, m pmetric.Metric) {
+		if m.Name() != metricName || found {
+			return
+		}
+		switch m.Type() {
+		case pmetric.MetricTypeGauge:
+			value = m.Gauge().DataPoints().At(0).IntValue()
+		case pmetric.MetricTypeSum:
+			value = m.Sum().DataPoints().At(0).IntValue()
+		default:
+			t.Fatalf("metric %q is not an int-valued number metric", metricName)
+		}
+		found = true
+	})
+	require.True(t, found, "metric %q not found", metricName)
+	return value
+}
+
+func metricDoubleValue(t *testing.T, metrics pmetric.Metrics, metricName string) float64 {
+	t.Helper()
+
+	var value float64
+	found := false
+	dp.ForEachMetric(&metrics, func(res pcommon.Resource, is pcommon.InstrumentationScope, m pmetric.Metric) {
+		if m.Name() != metricName || found {
+			return
+		}
+		switch m.Type() {
+		case pmetric.MetricTypeGauge:
+			value = m.Gauge().DataPoints().At(0).DoubleValue()
+		case pmetric.MetricTypeSum:
+			value = m.Sum().DataPoints().At(0).DoubleValue()
+		default:
+			t.Fatalf("metric %q is not a double-valued number metric", metricName)
+		}
+		found = true
+	})
+	require.True(t, found, "metric %q not found", metricName)
+	return value
+}
+
+func absInt64(v int64) int64 {
+	if v < 0 {
+		return -v
+	}
+	return v
+}

--- a/metricsgenreceiver/testdata/generation-hints-template-resource-attributes.json
+++ b/metricsgenreceiver/testdata/generation-hints-template-resource-attributes.json
@@ -1,0 +1,16 @@
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "host-{{.InstanceID}}"
+            }
+          }
+        ]
+      }
+    }
+  ]
+}

--- a/metricsgenreceiver/testdata/generation-hints-template.json
+++ b/metricsgenreceiver/testdata/generation-hints-template.json
@@ -1,0 +1,114 @@
+{
+  "resourceMetrics": [
+    {
+      "resource": {
+        "attributes": [
+          {
+            "key": "host.name",
+            "value": {
+              "stringValue": "hinted"
+            }
+          }
+        ]
+      },
+      "scopeMetrics": [
+        {
+          "metrics": [
+            {
+              "name": "test.constant",
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0",
+                    "asInt": "10"
+                  }
+                ]
+              },
+              "metadata": [
+                {
+                  "key": "metricsgen.hint.class",
+                  "value": {
+                    "stringValue": "constant"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "test.clock",
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0",
+                    "asDouble": 1000
+                  }
+                ]
+              },
+              "metadata": [
+                {
+                  "key": "metricsgen.hint.class",
+                  "value": {
+                    "stringValue": "clock"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "test.stable_binary",
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0",
+                    "asInt": "1"
+                  }
+                ]
+              },
+              "metadata": [
+                {
+                  "key": "metricsgen.hint.class",
+                  "value": {
+                    "stringValue": "stable_binary"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "test.current_count",
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0",
+                    "asInt": "10"
+                  }
+                ]
+              },
+              "metadata": [
+                {
+                  "key": "metricsgen.hint.class",
+                  "value": {
+                    "stringValue": "current_count"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "test.unhinted",
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0",
+                    "asDouble": 50
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Motivation

The default stochastic evolution (random walk for gauges, fixed-rate growth for counters) is a decent starting point but doesn't match how real metrics behave. Error counters grow every interval instead of sitting at 0 for hours; utilization gauges drift out of [0, 1]; "info" metrics with value 1 wander away from 1; wall-clock metrics don't track the collection interval. The mismatch hurts realism and compression efficiency — synthetic data collapses poorly compared to real node_exporter output.

Fixing this per-metric in code would couple the generator to every scenario it supports. Generation hints keep scenario authoring declarative: tag a metric with an evolution class that matches its real behavior, and the generator does the rest.

## Summary

- Introduces an optional `metricsgen.hint.class` metadata key that scenario authors can attach to individual metrics in a template. Supported classes: `clock`, `constant`, `current_count`, `slow_gauge`, `sparse_counter`, `stable_binary`, `steady_counter`.
- The receiver extracts and strips these hints at startup (`metricstmpl.ExtractGenerationHints`) so they never leak into emitted data, then uses them to replace the default stochastic advance with a class-specific evolution strategy in the shared template pass.
- No built-in scenarios are annotated in this PR — that's follow-up work (#42). This change only adds the framework, testdata fixtures, and a `TestReceiverAppliesGenerationHints` that exercises the classes end-to-end.

## Why inline metadata instead of a sidecar file

Hints live on the metric they describe, so renaming or deleting a metric can't silently orphan its hint. A previous iteration of this work used a `<path>-generation-hints.yaml` sidecar; this PR ships the inline form instead.

## Planned follow-up

Once #41 and #42 land, a third PR will add **stable per-instance variation** for number data points. Today, presence of a hint causes the per-instance emission pass to be skipped — which means every simulated host reports bit-identical values for any hinted metric. The follow-up replaces that skip with a deterministic hash-derived offset/multiplier per (instance ID × metric × attributes), so instances differ from each other realistically while each instance's series stays coherent across intervals. Histograms keep their existing rng-based advance.

## Test plan

- [ ] `make test` passes.
- [ ] `TestReceiverAppliesGenerationHints` asserts constant stays constant across intervals, clock advances by the collection interval, `stable_binary` stays at 0 or 1, `current_count` moves in small integer steps.
- [ ] `TestLoadGenerationHintsInvalidClass` / `TestLoadGenerationHintsMissingClass` / `TestExtractGenerationHintsNonStringMetadata` cover the validation paths.