### PR TITLE
feat(receiver): stable per-instance variation for number data points

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -54,7 +54,8 @@ When adding or updating a scenario:
    - Hints are supported only on number metrics (`Gauge` and `Sum`).
    - Hints are enforced per metric family within a scenario: if the same metric name appears multiple times, every occurrence must declare the same hint class or none of them may declare a hint.
    - Hints are not required and do not change the metric schema or the seeded values.
-   - Hints only affect how metric families evolve over time during synthetic generation.
+   - Hints control how metric families evolve over time on the shared template and how each instance's copy varies around it deterministically.
+   - Unhinted gauges and sums receive a small default per-instance multiplier, which produces no visible variation for int metrics with small absolute values; tag those with `current_count` so instances diverge by a deterministic integer offset instead.
    - Keep hints narrow and intentional. Add them for families whose behavior materially affects realism or compression.
    - For the supported hint classes and their intended behavior, see `metricsgenreceiver/internal/distribution/generation_hints.go`.
 

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ Given an initial set of resource metrics, this receiver generates metrics with a
 For example, given the output of a single report from the `hostmetricsreceiver`,
 lets you generate a day's worth of data from multiple simulated hosts with a given interval.
 
-The datapoints for the metrics are individually simulated using a distribution that can be customized with the `distribution` settings.
+Generation runs in two stages per interval.
+First, the shared metrics template is advanced stochastically using the `distribution` settings — this produces the baseline that every simulated instance sees.
+Second, each instance emits a copy of the template with a deterministic per-series variation layered on top, so instances differ from each other while each instance's series stays coherent over time.
+The variation for number data points is controlled by optional generation hints; histograms are still randomized per instance.
 
 ## Getting Started
 
@@ -91,12 +94,13 @@ receivers:
   Built-in templates:
   * `builtin/exponential-histograms-low-frequency.ndjson`: exponential histogram data with a low number of observations per histogram.
   * `builtin/exponential-histograms-high-frequency.ndjson`: exponential histogram data with a high number of observations per histogram.
-* `distribution`: the datapoints for the metrics are individually simulated by advancing their initial value using a standard distribution,
+* `distribution`: controls how the shared metrics template is advanced each interval,
   taking into account the [temporality](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#temporality),
   [monotonicity](https://opentelemetry.io/docs/specs/otel/metrics/data-model/#point-kinds),
   and capping floating point gauges values whose initial value is between 0 and 1 to that range.
   By changing the distribution parameters, you can simulate how predictable the metrics are evolving over time.
   This may have an impact on how well the backend can compress the data.
+  These settings only affect the shared template; per-instance variation for number data points is controlled separately by generation hints.
   * `median_monotonic_sum` (default `100`): the median value for the normal distribution used to simulate metrics that are monotonic sums.
     If the sum is not monotonic, or if the metric is a gauge, the median will always be zero, to simulate a value that goes up and down over time.
     If the temporality of the metric is delta, the new value will be set to the result of the normal distribution.
@@ -107,7 +111,8 @@ receivers:
     The new value will be incremented by the result of the normal distribution.
 * `scenarios`: a list of scenarios to simulate. For every interval, each scenario is simulated before moving to the next interval.
   * `scale`: determines how many instances (like hosts) to simulate.
-    The individual instances will a have a consistent set of resource attributes throughout the simulation.
+    The individual instances will have a consistent set of resource attributes throughout the simulation.
+    Each instance's number data points also get a deterministic per-series variation (hash-derived from instance ID + metric name + attributes) so that instances differ from each other without introducing noise into any single instance's time series.
   * `concurrency` (default `0`): when set to a non-zero value, the receiver will simulate the scenario concurrently with the specified number of goroutines.
   * `path`: the path of the scenario files.
     * Built-in scenarios:
@@ -130,7 +135,7 @@ receivers:
       The `<path>.json`/`<path>.yaml` file contains a single batch of resource metrics in JSON or YAML format, as produced by the `fileexporter`.
       The `<path>-resource-attributes.json`/`<path>-resource-attributes.yaml` file contains the resource attributes template.
       Optional generation hints can be declared inline on a number metric (`Gauge` or `Sum`) by adding a `metricsgen.hint.class` entry to its `metadata` block. Supported classes are `stable_binary`, `current_count`, `slow_gauge`, `steady_counter`, `sparse_counter`, `clock`, and `constant`.
-      These hints only affect how values evolve over time during synthetic generation. The receiver strips the hint metadata at startup so it does not leak into emitted data. Hints are enforced per metric name within a scenario: if the same metric name appears multiple times, every occurrence must declare the same hint class or none of them may declare a hint.
+      Hints control how values evolve on the shared template and how each instance's copy varies around it deterministically. The receiver strips the hint metadata at startup so it does not leak into emitted data. Hints are enforced per metric name within a scenario: if the same metric name appears multiple times, every occurrence must declare the same hint class or none of them may declare a hint.
       The resource attributes template is used to simulate the individual instances.
       These resource attributes are injected into all resource metrics for which a matching resource attribute key exists.
       Supported placeholders:

--- a/metricsgenreceiver/internal/distribution/distribution.go
+++ b/metricsgenreceiver/internal/distribution/distribution.go
@@ -121,10 +121,18 @@ func AdvanceDataPoint(dp dp.DataPoint, r *rand.Rand, m pmetric.Metric, dist Dist
 
 func advanceZeroToOne(value float64, rand *rand.Rand, dist DistributionCfg) float64 {
 	value += rand.NormFloat64() * dist.StdDevGaugePct
-	// keep locked between 0..1
+	return bounceBetweenZeroAndOne(value)
+}
+
+// bounceBetweenZeroAndOne keeps a value in [0, 1] by reflecting it at the
+// boundaries instead of saturating at either edge.
+func bounceBetweenZeroAndOne(value float64) float64 {
 	value = math.Abs(value)
-	value = min(value, 1)
-	return value
+	fractional := math.Mod(value, 1.0)
+	if int(value)%2 == 0 {
+		return fractional
+	}
+	return 1.0 - fractional
 }
 
 func advanceInt(rand *rand.Rand, m pmetric.Metric, value int64, dist DistributionCfg) int64 {

--- a/metricsgenreceiver/internal/distribution/distribution.go
+++ b/metricsgenreceiver/internal/distribution/distribution.go
@@ -33,7 +33,7 @@ type AdvanceOptions struct {
 
 func InferPrecision(metrics *pmetric.Metrics) map[string]int {
 	precision := make(map[string]int)
-	dp.ForEachDataPoint(metrics, func(_ pcommon.Resource, _ pcommon.InstrumentationScope, m pmetric.Metric, d dp.DataPoint) {
+	dp.ForEachDataPoint(metrics, func(_ int, _ pcommon.Resource, _ pcommon.InstrumentationScope, m pmetric.Metric, d dp.DataPoint) {
 		ndp, ok := d.(pmetric.NumberDataPoint)
 		if !ok || ndp.ValueType() != pmetric.NumberDataPointValueTypeDouble {
 			return

--- a/metricsgenreceiver/internal/distribution/generation_hints.go
+++ b/metricsgenreceiver/internal/distribution/generation_hints.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"strings"
 
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
@@ -14,22 +13,22 @@ type GenerationHintClass string
 const (
 	// GenerationHintClock advances a time-like metric deterministically with the collection interval.
 	// Example: node_time_seconds.
-	GenerationHintClock         GenerationHintClass = "clock"
+	GenerationHintClock GenerationHintClass = "clock"
 	// GenerationHintConstant keeps a metric fixed after its initial seed value.
 	// Examples: node_memory_MemTotal_bytes, node_boot_time_seconds.
-	GenerationHintConstant      GenerationHintClass = "constant"
+	GenerationHintConstant GenerationHintClass = "constant"
 	// GenerationHintCurrentCount models a non-negative integer count that changes in small steps.
 	// Examples: system.network.connections, node_sockstat_TCP_inuse.
-	GenerationHintCurrentCount  GenerationHintClass = "current_count"
+	GenerationHintCurrentCount GenerationHintClass = "current_count"
 	// GenerationHintSlowGauge models a gauge that moves gradually instead of wandering wildly between intervals.
 	// Examples: system.cpu.utilization, system.memory.usage.
-	GenerationHintSlowGauge     GenerationHintClass = "slow_gauge"
+	GenerationHintSlowGauge GenerationHintClass = "slow_gauge"
 	// GenerationHintSparseCounter models a counter-like series that is flat most intervals and only increases occasionally.
 	// Examples: system.network.errors, node_vmstat_oom_kill.
 	GenerationHintSparseCounter GenerationHintClass = "sparse_counter"
 	// GenerationHintStableBinary keeps a metric strictly at 0 or 1 and never flips after the seed is normalized.
 	// Examples: node_network_up, node_filesystem_readonly.
-	GenerationHintStableBinary  GenerationHintClass = "stable_binary"
+	GenerationHintStableBinary GenerationHintClass = "stable_binary"
 	// GenerationHintSteadyCounter models a counter-like series that increases at a fairly stable rate most intervals.
 	// Examples: system.cpu.time, node_network_receive_bytes_total.
 	GenerationHintSteadyCounter GenerationHintClass = "steady_counter"
@@ -126,11 +125,11 @@ func (currentCountStrategy) Advance(current float64, rand *rand.Rand, _ pmetric.
 
 type slowGaugeStrategy struct{}
 
-func (slowGaugeStrategy) Advance(current float64, rand *rand.Rand, metric pmetric.Metric, dist DistributionCfg, _ AdvanceOptions) float64 {
+func (slowGaugeStrategy) Advance(current float64, rand *rand.Rand, _ pmetric.Metric, dist DistributionCfg, _ AdvanceOptions) float64 {
 	scale := math.Max(math.Abs(current), 1)
 	value := math.Abs(current + rand.NormFloat64()*math.Max(dist.StdDev*0.2, scale*0.005))
-	if strings.HasSuffix(metric.Name(), ".utilization") {
-		value = min(value, 1)
+	if isUnitIntervalGaugeValue(current) {
+		value = bounceBetweenZeroAndOne(value)
 	}
 	return value
 }

--- a/metricsgenreceiver/internal/distribution/instance_variation.go
+++ b/metricsgenreceiver/internal/distribution/instance_variation.go
@@ -18,6 +18,11 @@ const (
 	counterRateWaveAmplitude        = 0.80
 	counterRateWavePeriodIntervals  = 20.0
 	temporalVariationBucketCount    = 10
+
+	minGaugeMultiplier   = 1.00
+	maxGaugeMultiplier   = 2.00
+	minCounterMultiplier = 0.90
+	maxCounterMultiplier = 1.10
 )
 
 // InstanceVariationStrategy applies deterministic per-instance variation to a number data point.
@@ -37,15 +42,13 @@ type InstanceVariationStrategy interface {
 }
 
 var instanceVariations = map[GenerationHintClass]InstanceVariationStrategy{
-	GenerationHintClock:        noInstanceVariation{},
-	GenerationHintConstant:     noInstanceVariation{},
-	GenerationHintStableBinary: noInstanceVariation{},
-	GenerationHintCurrentCount: integerOffsetVariation{min: -2, max: 2},
-	// Keep gauge multipliers >= 1 so non-unit gauges do not get pushed below 1
-	// and accidentally become eligible for [0,1] bouncing on later intervals.
-	GenerationHintSlowGauge:     boundedMultiplierVariation{min: 1.00, max: 2.00, autoBounceBetweenZeroAndOne: true},
-	GenerationHintSparseCounter: boundedMultiplierVariation{min: 0.90, max: 1.10},
-	GenerationHintSteadyCounter: boundedMultiplierVariation{min: 0.90, max: 1.10},
+	GenerationHintClock:         noInstanceVariation{},
+	GenerationHintConstant:      noInstanceVariation{},
+	GenerationHintStableBinary:  noInstanceVariation{},
+	GenerationHintCurrentCount:  currentCountVariation{minOffset: -2, maxOffset: 2},
+	GenerationHintSlowGauge:     gaugeVariation(),
+	GenerationHintSparseCounter: counterVariation(),
+	GenerationHintSteadyCounter: counterVariation(),
 }
 
 // ApplyInstanceVariation applies deterministic per-instance variation to a number data point.
@@ -105,11 +108,9 @@ func strategyFor(metric pmetric.Metric, hints map[string]MetricGenerationHint) I
 func defaultInstanceVariationFor(metric pmetric.Metric) InstanceVariationStrategy {
 	switch metric.Type() {
 	case pmetric.MetricTypeGauge:
-		// Keep gauge multipliers >= 1 so non-unit gauges do not get pushed below 1
-		// and accidentally become eligible for [0,1] bouncing on later intervals.
-		return boundedMultiplierVariation{min: 1.00, max: 2.00, autoBounceBetweenZeroAndOne: true}
+		return gaugeVariation()
 	case pmetric.MetricTypeSum:
-		return boundedMultiplierVariation{min: 0.90, max: 1.10}
+		return counterVariation()
 	default:
 		return noInstanceVariation{}
 	}
@@ -126,44 +127,81 @@ type boundedMultiplierVariation struct {
 	autoBounceBetweenZeroAndOne bool
 }
 
+func gaugeVariation() boundedMultiplierVariation {
+	return boundedMultiplierVariation{
+		min:                         minGaugeMultiplier,
+		max:                         maxGaugeMultiplier,
+		autoBounceBetweenZeroAndOne: true,
+	}
+}
+
+func counterVariation() boundedMultiplierVariation {
+	return boundedMultiplierVariation{
+		min: minCounterMultiplier,
+		max: maxCounterMultiplier,
+	}
+}
+
 func (s boundedMultiplierVariation) ApplyNumber(v pmetric.NumberDataPoint, instanceID int, identityHash uint64, metric pmetric.Metric, precision map[string]int, opts InstanceVariationOptions) {
 	current := currentNumberDataPointValue(v)
 	if current == 0 {
 		return
 	}
 	instanceUnit := hashToUnitInterval(mixInstanceID(identityHash, instanceID))
-	multiplier := s.min + (s.max-s.min)*instanceUnit
-	next := current * multiplier
+	var next float64
 	if isCumulativeMonotonicSum(metric) {
-		next += counterElapsedOffset(identityHash, instanceID, instanceUnit, opts)
+		next = s.applyCumulativeCounterVariation(current, identityHash, instanceID, instanceUnit, opts)
 	} else {
-		next *= temporalMultiplier(identityHash, instanceID, opts, isUnitIntervalGaugeValue(current))
-	}
-	next = math.Max(0, next)
-	if s.autoBounceBetweenZeroAndOne && isUnitIntervalGaugeValue(current) {
-		next = bounceBetweenZeroAndOne(next)
+		next = s.applyNonCumulativeVariation(current, identityHash, instanceID, instanceUnit, opts)
 	}
 	writeNumberDataPoint(v, next, metric, precision)
 }
 
-type integerOffsetVariation struct {
-	min int64
-	max int64
+func (s boundedMultiplierVariation) applyCumulativeCounterVariation(current float64, identityHash uint64, instanceID int, instanceUnit float64, opts InstanceVariationOptions) float64 {
+	next := current * stableMultiplier(s.min, s.max, instanceUnit)
+	next += counterRateOffset(identityHash, instanceID, instanceUnit, opts)
+	return math.Max(0, next)
 }
 
-func (s integerOffsetVariation) ApplyNumber(v pmetric.NumberDataPoint, instanceID int, identityHash uint64, metric pmetric.Metric, precision map[string]int, opts InstanceVariationOptions) {
+func (s boundedMultiplierVariation) applyNonCumulativeVariation(current float64, identityHash uint64, instanceID int, instanceUnit float64, opts InstanceVariationOptions) float64 {
+	isUnitInterval := isUnitIntervalGaugeValue(current)
+	next := current * stableMultiplier(s.min, s.max, instanceUnit)
+	next *= temporalMultiplier(identityHash, instanceID, opts, isUnitInterval)
+	next = math.Max(0, next)
+	if s.autoBounceBetweenZeroAndOne && isUnitInterval {
+		next = bounceBetweenZeroAndOne(next)
+	}
+	return next
+}
+
+type currentCountVariation struct {
+	minOffset int64
+	maxOffset int64
+}
+
+func (s currentCountVariation) ApplyNumber(v pmetric.NumberDataPoint, instanceID int, identityHash uint64, metric pmetric.Metric, precision map[string]int, opts InstanceVariationOptions) {
 	current := currentNumberDataPointValue(v)
-	span := s.max - s.min + 1
+	span := s.maxOffset - s.minOffset + 1
 	if span <= 0 {
 		panic("invalid integer offset bounds")
 	}
 	base := int64(identityHash % uint64(span))
-	offset := positiveMod(int64(instanceID)+base, span) + s.min
+	offset := positiveMod(int64(instanceID)+base, span) + s.minOffset
 	offset += int64(math.Round(currentCountTemporalOffsetMax * temporalNoise(identityHash, instanceID, opts)))
 	instanceUnit := hashToUnitInterval(mixInstanceID(identityHash, instanceID))
-	multiplier := 1.00 + instanceUnit
+	multiplier := stableGaugeMultiplier(instanceUnit)
 	next := math.Max(0, current*multiplier+float64(offset))
 	writeNumberDataPoint(v, next, metric, precision)
+}
+
+func stableGaugeMultiplier(instanceUnit float64) float64 {
+	// Keep gauge multipliers >= 1 so non-unit gauges do not get pushed below 1
+	// and accidentally become eligible for [0,1] bouncing on later intervals.
+	return stableMultiplier(minGaugeMultiplier, maxGaugeMultiplier, instanceUnit)
+}
+
+func stableMultiplier(minValue, maxValue, unit float64) float64 {
+	return minValue + (maxValue-minValue)*unit
 }
 
 func isUnitIntervalGaugeValue(v float64) bool {
@@ -187,7 +225,7 @@ func temporalMultiplier(identityHash uint64, instanceID int, opts InstanceVariat
 	return 1 + gaugeTemporalVariationAmplitude*noise
 }
 
-func counterElapsedOffset(identityHash uint64, instanceID int, instanceUnit float64, opts InstanceVariationOptions) float64 {
+func counterRateOffset(identityHash uint64, instanceID int, instanceUnit float64, opts InstanceVariationOptions) float64 {
 	if opts.Timestamp.IsZero() || opts.StartTime.IsZero() || opts.Interval <= 0 {
 		return 0
 	}
@@ -201,6 +239,8 @@ func counterElapsedOffset(identityHash uint64, instanceID int, instanceUnit floa
 }
 
 func integratedCounterRateWave(elapsed float64, phase float64) float64 {
+	// Integrate a positive rate wave so cumulative counters stay monotonic while
+	// rate() views still see time-varying per-instance movement.
 	angularFrequency := 2 * math.Pi / counterRateWavePeriodIntervals
 	return elapsed + counterRateWaveAmplitude/angularFrequency*(math.Sin(angularFrequency*elapsed+phase)-math.Sin(phase))
 }

--- a/metricsgenreceiver/internal/distribution/instance_variation.go
+++ b/metricsgenreceiver/internal/distribution/instance_variation.go
@@ -14,7 +14,7 @@ import (
 
 const (
 	gaugeTemporalVariationAmplitude = 0.04
-	counterElapsedMultiplierMax     = 0.20
+	counterExtraRateMax             = 0.20
 	temporalVariationBucketCount    = 10
 )
 
@@ -55,9 +55,10 @@ func ApplyInstanceVariation(v pmetric.NumberDataPoint, instanceID int, identityH
 // InstanceVariationOptions contains timing information used for stateless,
 // time-varying per-instance variation.
 type InstanceVariationOptions struct {
-	Timestamp time.Time
-	StartTime time.Time
-	Interval  time.Duration
+	Timestamp        time.Time
+	StartTime        time.Time
+	Interval         time.Duration
+	CounterBaseDelta float64
 }
 
 // InstanceEmitOptions carries the state needed to emit a data point for one specific instance.
@@ -126,7 +127,7 @@ func (s boundedMultiplierVariation) ApplyNumber(v pmetric.NumberDataPoint, insta
 	multiplier := s.min + (s.max-s.min)*instanceUnit
 	next := current * multiplier
 	if isCumulativeMonotonicSum(metric) {
-		next += current * counterElapsedMultiplier(instanceUnit, opts)
+		next += counterElapsedOffset(instanceUnit, opts)
 	} else {
 		next *= temporalMultiplier(identityHash, instanceID, opts)
 	}
@@ -167,7 +168,7 @@ func temporalMultiplier(identityHash uint64, instanceID int, opts InstanceVariat
 	return 1 + gaugeTemporalVariationAmplitude*temporalNoise(identityHash, instanceID, opts)
 }
 
-func counterElapsedMultiplier(instanceUnit float64, opts InstanceVariationOptions) float64 {
+func counterElapsedOffset(instanceUnit float64, opts InstanceVariationOptions) float64 {
 	if opts.Timestamp.IsZero() || opts.StartTime.IsZero() || opts.Interval <= 0 {
 		return 0
 	}
@@ -175,9 +176,7 @@ func counterElapsedMultiplier(instanceUnit float64, opts InstanceVariationOption
 	if elapsed <= 0 {
 		return 0
 	}
-	// Ramp toward a bounded extra multiplier so cumulative counters stay monotonic
-	// without per-series state or a time-varying factor that can shrink.
-	return counterElapsedMultiplierMax * instanceUnit * elapsed / (elapsed + temporalVariationBucketCount)
+	return opts.CounterBaseDelta * counterExtraRateMax * instanceUnit * elapsed
 }
 
 func temporalNoise(identityHash uint64, instanceID int, opts InstanceVariationOptions) float64 {

--- a/metricsgenreceiver/internal/distribution/instance_variation.go
+++ b/metricsgenreceiver/internal/distribution/instance_variation.go
@@ -1,0 +1,152 @@
+package distribution
+
+import (
+	"fmt"
+	"math"
+	"math/rand"
+	"strings"
+
+	"github.com/elastic/metricsgenreceiver/metricsgenreceiver/internal/dp"
+	"github.com/elastic/metricsgenreceiver/metricsgenreceiver/internal/expohistogen"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+// InstanceVariationStrategy applies deterministic per-instance variation to a number data point.
+// It is only invoked during the per-instance emission pass, once per instance per data point per
+// interval — after the shared template has already been advanced via GenerationHintStrategy. The
+// template advance pass does not call ApplyNumber.
+//
+// The variation is a stable function of (instanceID, metric name, data-point attributes) — it does
+// not introduce random walk at emission time, which keeps each instance's series coherent over
+// successive intervals. Strategies receive a precomputed identityHash for (metric name, attributes)
+// so they can avoid re-hashing the attribute set on every data-point emission; see IdentityHash.
+//
+// Implementations must be stateless: keeping per-series state would violate the project's
+// bounded-memory design principle.
+type InstanceVariationStrategy interface {
+	ApplyNumber(v pmetric.NumberDataPoint, instanceID int, identityHash uint64, metric pmetric.Metric, precision map[string]int)
+}
+
+var instanceVariations = map[GenerationHintClass]InstanceVariationStrategy{
+	GenerationHintClock:         noInstanceVariation{},
+	GenerationHintConstant:      noInstanceVariation{},
+	GenerationHintStableBinary:  noInstanceVariation{},
+	GenerationHintCurrentCount:  integerOffsetVariation{min: -2, max: 2},
+	GenerationHintSlowGauge:     boundedMultiplierVariation{min: 0.95, max: 1.05, clampUtilization: true},
+	GenerationHintSparseCounter: boundedMultiplierVariation{min: 0.95, max: 1.05},
+	GenerationHintSteadyCounter: boundedMultiplierVariation{min: 0.95, max: 1.05},
+}
+
+// ApplyInstanceVariation applies deterministic per-instance variation to a number data point.
+// If a hint is configured for the metric, its declared variation strategy is used; otherwise the
+// variation is inferred from the metric shape. identityHash must be the value returned by
+// IdentityHash for this data point.
+func ApplyInstanceVariation(v pmetric.NumberDataPoint, instanceID int, identityHash uint64, metric pmetric.Metric, hints map[string]MetricGenerationHint, precision map[string]int) {
+	strategyFor(metric, hints).ApplyNumber(v, instanceID, identityHash, metric, precision)
+}
+
+// InstanceEmitOptions carries the state needed to emit a data point for one specific instance.
+// NumberDataPoints go through the stable per-series variation path (InstanceID + IdentityHash +
+// Hints); other data-point types (histograms, summaries) fall back to the randomised advance and
+// use Rand / Dist / ExpHistoGen.
+type InstanceEmitOptions struct {
+	InstanceID   int
+	IdentityHash uint64
+	Hints        map[string]MetricGenerationHint
+	Precision    map[string]int
+	Rand         *rand.Rand
+	Dist         DistributionCfg
+	ExpHistoGen  *expohistogen.Generator
+}
+
+// EmitForInstance is the single entry point the receiver uses to emit a data point for an
+// instance. It hides the dispatch over data-point types so callers don't need to type-switch.
+func EmitForInstance(dataPoint dp.DataPoint, metric pmetric.Metric, opts InstanceEmitOptions) {
+	switch v := dataPoint.(type) {
+	case pmetric.NumberDataPoint:
+		ApplyInstanceVariation(v, opts.InstanceID, opts.IdentityHash, metric, opts.Hints, opts.Precision)
+	default:
+		AdvanceDataPoint(dataPoint, opts.Rand, metric, opts.Dist, opts.ExpHistoGen, AdvanceOptions{Precision: opts.Precision})
+	}
+}
+
+func strategyFor(metric pmetric.Metric, hints map[string]MetricGenerationHint) InstanceVariationStrategy {
+	if hint, ok := hints[metric.Name()]; ok {
+		strategy, ok := instanceVariations[hint.Class]
+		if !ok {
+			panic(fmt.Sprintf("unsupported generation hint class %q", hint.Class))
+		}
+		return strategy
+	}
+	return defaultInstanceVariationFor(metric)
+}
+
+func defaultInstanceVariationFor(metric pmetric.Metric) InstanceVariationStrategy {
+	switch metric.Type() {
+	case pmetric.MetricTypeGauge, pmetric.MetricTypeSum:
+		return boundedMultiplierVariation{min: 0.95, max: 1.05, clampUtilization: true}
+	default:
+		return noInstanceVariation{}
+	}
+}
+
+type noInstanceVariation struct{}
+
+func (noInstanceVariation) ApplyNumber(pmetric.NumberDataPoint, int, uint64, pmetric.Metric, map[string]int) {
+}
+
+type boundedMultiplierVariation struct {
+	min              float64
+	max              float64
+	clampUtilization bool
+}
+
+func (s boundedMultiplierVariation) ApplyNumber(v pmetric.NumberDataPoint, instanceID int, identityHash uint64, metric pmetric.Metric, precision map[string]int) {
+	current := currentNumberDataPointValue(v)
+	if current == 0 {
+		return
+	}
+	multiplier := s.min + (s.max-s.min)*hashToUnitInterval(mixInstanceID(identityHash, instanceID))
+	next := math.Max(0, current*multiplier)
+	if s.clampUtilization && strings.HasSuffix(metric.Name(), ".utilization") {
+		next = min(next, 1)
+	}
+	writeNumberDataPoint(v, next, metric, precision)
+}
+
+type integerOffsetVariation struct {
+	min int64
+	max int64
+}
+
+func (s integerOffsetVariation) ApplyNumber(v pmetric.NumberDataPoint, instanceID int, identityHash uint64, metric pmetric.Metric, precision map[string]int) {
+	current := currentNumberDataPointValue(v)
+	span := s.max - s.min + 1
+	if span <= 0 {
+		panic("invalid integer offset bounds")
+	}
+	base := int64(identityHash % uint64(span))
+	offset := positiveMod(int64(instanceID)+base, span) + s.min
+	next := math.Max(0, current+float64(offset))
+	writeNumberDataPoint(v, next, metric, precision)
+}
+
+func writeNumberDataPoint(v pmetric.NumberDataPoint, next float64, metric pmetric.Metric, precision map[string]int) {
+	switch v.ValueType() {
+	case pmetric.NumberDataPointValueTypeDouble:
+		if p, ok := precision[metric.Name()]; ok {
+			next = roundToPrecision(next, p)
+		}
+		v.SetDoubleValue(next)
+	case pmetric.NumberDataPointValueTypeInt:
+		v.SetIntValue(int64(math.Max(0, math.Round(next))))
+	}
+}
+
+func positiveMod(v int64, mod int64) int64 {
+	r := v % mod
+	if r < 0 {
+		r += mod
+	}
+	return r
+}

--- a/metricsgenreceiver/internal/distribution/instance_variation.go
+++ b/metricsgenreceiver/internal/distribution/instance_variation.go
@@ -12,9 +12,11 @@ import (
 )
 
 const (
-	gaugeTemporalVariationAmplitude = 0.04
+	gaugeTemporalVariationAmplitude = 0.08
 	currentCountTemporalOffsetMax   = 3
 	counterExtraRateMax             = 0.20
+	counterRateWaveAmplitude        = 0.80
+	counterRateWavePeriodIntervals  = 20.0
 	temporalVariationBucketCount    = 10
 )
 
@@ -35,11 +37,13 @@ type InstanceVariationStrategy interface {
 }
 
 var instanceVariations = map[GenerationHintClass]InstanceVariationStrategy{
-	GenerationHintClock:         noInstanceVariation{},
-	GenerationHintConstant:      noInstanceVariation{},
-	GenerationHintStableBinary:  noInstanceVariation{},
-	GenerationHintCurrentCount:  integerOffsetVariation{min: -2, max: 2},
-	GenerationHintSlowGauge:     boundedMultiplierVariation{min: 0.80, max: 1.20, autoBounceBetweenZeroAndOne: true},
+	GenerationHintClock:        noInstanceVariation{},
+	GenerationHintConstant:     noInstanceVariation{},
+	GenerationHintStableBinary: noInstanceVariation{},
+	GenerationHintCurrentCount: integerOffsetVariation{min: -2, max: 2},
+	// Keep gauge multipliers >= 1 so non-unit gauges do not get pushed below 1
+	// and accidentally become eligible for [0,1] bouncing on later intervals.
+	GenerationHintSlowGauge:     boundedMultiplierVariation{min: 1.00, max: 2.00, autoBounceBetweenZeroAndOne: true},
 	GenerationHintSparseCounter: boundedMultiplierVariation{min: 0.90, max: 1.10},
 	GenerationHintSteadyCounter: boundedMultiplierVariation{min: 0.90, max: 1.10},
 }
@@ -101,7 +105,9 @@ func strategyFor(metric pmetric.Metric, hints map[string]MetricGenerationHint) I
 func defaultInstanceVariationFor(metric pmetric.Metric) InstanceVariationStrategy {
 	switch metric.Type() {
 	case pmetric.MetricTypeGauge:
-		return boundedMultiplierVariation{min: 0.80, max: 1.20, autoBounceBetweenZeroAndOne: true}
+		// Keep gauge multipliers >= 1 so non-unit gauges do not get pushed below 1
+		// and accidentally become eligible for [0,1] bouncing on later intervals.
+		return boundedMultiplierVariation{min: 1.00, max: 2.00, autoBounceBetweenZeroAndOne: true}
 	case pmetric.MetricTypeSum:
 		return boundedMultiplierVariation{min: 0.90, max: 1.10}
 	default:
@@ -129,9 +135,9 @@ func (s boundedMultiplierVariation) ApplyNumber(v pmetric.NumberDataPoint, insta
 	multiplier := s.min + (s.max-s.min)*instanceUnit
 	next := current * multiplier
 	if isCumulativeMonotonicSum(metric) {
-		next += counterElapsedOffset(instanceUnit, opts)
+		next += counterElapsedOffset(identityHash, instanceID, instanceUnit, opts)
 	} else {
-		next *= temporalMultiplier(identityHash, instanceID, opts)
+		next *= temporalMultiplier(identityHash, instanceID, opts, isUnitIntervalGaugeValue(current))
 	}
 	next = math.Max(0, next)
 	if s.autoBounceBetweenZeroAndOne && isUnitIntervalGaugeValue(current) {
@@ -155,7 +161,7 @@ func (s integerOffsetVariation) ApplyNumber(v pmetric.NumberDataPoint, instanceI
 	offset := positiveMod(int64(instanceID)+base, span) + s.min
 	offset += int64(math.Round(currentCountTemporalOffsetMax * temporalNoise(identityHash, instanceID, opts)))
 	instanceUnit := hashToUnitInterval(mixInstanceID(identityHash, instanceID))
-	multiplier := 0.80 + 0.40*instanceUnit
+	multiplier := 1.00 + instanceUnit
 	next := math.Max(0, current*multiplier+float64(offset))
 	writeNumberDataPoint(v, next, metric, precision)
 }
@@ -170,14 +176,18 @@ func isCumulativeMonotonicSum(metric pmetric.Metric) bool {
 		metric.Sum().AggregationTemporality() == pmetric.AggregationTemporalityCumulative
 }
 
-func temporalMultiplier(identityHash uint64, instanceID int, opts InstanceVariationOptions) float64 {
+func temporalMultiplier(identityHash uint64, instanceID int, opts InstanceVariationOptions, allowNegativeNoise bool) float64 {
 	if opts.Timestamp.IsZero() || opts.Interval <= 0 {
 		return 1
 	}
-	return 1 + gaugeTemporalVariationAmplitude*temporalNoise(identityHash, instanceID, opts)
+	noise := temporalNoise(identityHash, instanceID, opts)
+	if !allowNegativeNoise {
+		noise = 0.5 + 0.5*noise
+	}
+	return 1 + gaugeTemporalVariationAmplitude*noise
 }
 
-func counterElapsedOffset(instanceUnit float64, opts InstanceVariationOptions) float64 {
+func counterElapsedOffset(identityHash uint64, instanceID int, instanceUnit float64, opts InstanceVariationOptions) float64 {
 	if opts.Timestamp.IsZero() || opts.StartTime.IsZero() || opts.Interval <= 0 {
 		return 0
 	}
@@ -185,7 +195,14 @@ func counterElapsedOffset(instanceUnit float64, opts InstanceVariationOptions) f
 	if elapsed <= 0 {
 		return 0
 	}
-	return opts.CounterBaseDelta * counterExtraRateMax * instanceUnit * elapsed
+	phase := 2 * math.Pi * hashToUnitInterval(mixInstanceID(identityHash^0x94d049bb133111eb, instanceID))
+	wave := integratedCounterRateWave(elapsed, phase)
+	return opts.CounterBaseDelta * counterExtraRateMax * instanceUnit * wave
+}
+
+func integratedCounterRateWave(elapsed float64, phase float64) float64 {
+	angularFrequency := 2 * math.Pi / counterRateWavePeriodIntervals
+	return elapsed + counterRateWaveAmplitude/angularFrequency*(math.Sin(angularFrequency*elapsed+phase)-math.Sin(phase))
 }
 
 func temporalNoise(identityHash uint64, instanceID int, opts InstanceVariationOptions) float64 {

--- a/metricsgenreceiver/internal/distribution/instance_variation.go
+++ b/metricsgenreceiver/internal/distribution/instance_variation.go
@@ -4,7 +4,6 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
-	"strings"
 	"time"
 
 	"github.com/elastic/metricsgenreceiver/metricsgenreceiver/internal/dp"
@@ -14,6 +13,7 @@ import (
 
 const (
 	gaugeTemporalVariationAmplitude = 0.04
+	currentCountTemporalOffsetMax   = 3
 	counterExtraRateMax             = 0.20
 	temporalVariationBucketCount    = 10
 )
@@ -39,9 +39,9 @@ var instanceVariations = map[GenerationHintClass]InstanceVariationStrategy{
 	GenerationHintConstant:      noInstanceVariation{},
 	GenerationHintStableBinary:  noInstanceVariation{},
 	GenerationHintCurrentCount:  integerOffsetVariation{min: -2, max: 2},
-	GenerationHintSlowGauge:     boundedMultiplierVariation{min: 0.95, max: 1.05, clampUtilization: true},
-	GenerationHintSparseCounter: boundedMultiplierVariation{min: 0.95, max: 1.05},
-	GenerationHintSteadyCounter: boundedMultiplierVariation{min: 0.95, max: 1.05},
+	GenerationHintSlowGauge:     boundedMultiplierVariation{min: 0.80, max: 1.20, autoBounceBetweenZeroAndOne: true},
+	GenerationHintSparseCounter: boundedMultiplierVariation{min: 0.90, max: 1.10},
+	GenerationHintSteadyCounter: boundedMultiplierVariation{min: 0.90, max: 1.10},
 }
 
 // ApplyInstanceVariation applies deterministic per-instance variation to a number data point.
@@ -100,8 +100,10 @@ func strategyFor(metric pmetric.Metric, hints map[string]MetricGenerationHint) I
 
 func defaultInstanceVariationFor(metric pmetric.Metric) InstanceVariationStrategy {
 	switch metric.Type() {
-	case pmetric.MetricTypeGauge, pmetric.MetricTypeSum:
-		return boundedMultiplierVariation{min: 0.95, max: 1.05, clampUtilization: true}
+	case pmetric.MetricTypeGauge:
+		return boundedMultiplierVariation{min: 0.80, max: 1.20, autoBounceBetweenZeroAndOne: true}
+	case pmetric.MetricTypeSum:
+		return boundedMultiplierVariation{min: 0.90, max: 1.10}
 	default:
 		return noInstanceVariation{}
 	}
@@ -113,9 +115,9 @@ func (noInstanceVariation) ApplyNumber(pmetric.NumberDataPoint, int, uint64, pme
 }
 
 type boundedMultiplierVariation struct {
-	min              float64
-	max              float64
-	clampUtilization bool
+	min                         float64
+	max                         float64
+	autoBounceBetweenZeroAndOne bool
 }
 
 func (s boundedMultiplierVariation) ApplyNumber(v pmetric.NumberDataPoint, instanceID int, identityHash uint64, metric pmetric.Metric, precision map[string]int, opts InstanceVariationOptions) {
@@ -132,8 +134,8 @@ func (s boundedMultiplierVariation) ApplyNumber(v pmetric.NumberDataPoint, insta
 		next *= temporalMultiplier(identityHash, instanceID, opts)
 	}
 	next = math.Max(0, next)
-	if s.clampUtilization && strings.HasSuffix(metric.Name(), ".utilization") {
-		next = min(next, 1)
+	if s.autoBounceBetweenZeroAndOne && isUnitIntervalGaugeValue(current) {
+		next = bounceBetweenZeroAndOne(next)
 	}
 	writeNumberDataPoint(v, next, metric, precision)
 }
@@ -151,8 +153,15 @@ func (s integerOffsetVariation) ApplyNumber(v pmetric.NumberDataPoint, instanceI
 	}
 	base := int64(identityHash % uint64(span))
 	offset := positiveMod(int64(instanceID)+base, span) + s.min
-	next := math.Max(0, current+float64(offset))
+	offset += int64(math.Round(currentCountTemporalOffsetMax * temporalNoise(identityHash, instanceID, opts)))
+	instanceUnit := hashToUnitInterval(mixInstanceID(identityHash, instanceID))
+	multiplier := 0.80 + 0.40*instanceUnit
+	next := math.Max(0, current*multiplier+float64(offset))
 	writeNumberDataPoint(v, next, metric, precision)
+}
+
+func isUnitIntervalGaugeValue(v float64) bool {
+	return v >= 0 && v <= 1
 }
 
 func isCumulativeMonotonicSum(metric pmetric.Metric) bool {

--- a/metricsgenreceiver/internal/distribution/instance_variation.go
+++ b/metricsgenreceiver/internal/distribution/instance_variation.go
@@ -5,10 +5,17 @@ import (
 	"math"
 	"math/rand"
 	"strings"
+	"time"
 
 	"github.com/elastic/metricsgenreceiver/metricsgenreceiver/internal/dp"
 	"github.com/elastic/metricsgenreceiver/metricsgenreceiver/internal/expohistogen"
 	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+const (
+	gaugeTemporalVariationAmplitude = 0.04
+	counterElapsedMultiplierMax     = 0.20
+	temporalVariationBucketCount    = 10
 )
 
 // InstanceVariationStrategy applies deterministic per-instance variation to a number data point.
@@ -24,7 +31,7 @@ import (
 // Implementations must be stateless: keeping per-series state would violate the project's
 // bounded-memory design principle.
 type InstanceVariationStrategy interface {
-	ApplyNumber(v pmetric.NumberDataPoint, instanceID int, identityHash uint64, metric pmetric.Metric, precision map[string]int)
+	ApplyNumber(v pmetric.NumberDataPoint, instanceID int, identityHash uint64, metric pmetric.Metric, precision map[string]int, opts InstanceVariationOptions)
 }
 
 var instanceVariations = map[GenerationHintClass]InstanceVariationStrategy{
@@ -41,8 +48,16 @@ var instanceVariations = map[GenerationHintClass]InstanceVariationStrategy{
 // If a hint is configured for the metric, its declared variation strategy is used; otherwise the
 // variation is inferred from the metric shape. identityHash must be the value returned by
 // IdentityHash for this data point.
-func ApplyInstanceVariation(v pmetric.NumberDataPoint, instanceID int, identityHash uint64, metric pmetric.Metric, hints map[string]MetricGenerationHint, precision map[string]int) {
-	strategyFor(metric, hints).ApplyNumber(v, instanceID, identityHash, metric, precision)
+func ApplyInstanceVariation(v pmetric.NumberDataPoint, instanceID int, identityHash uint64, metric pmetric.Metric, hints map[string]MetricGenerationHint, precision map[string]int, opts InstanceVariationOptions) {
+	strategyFor(metric, hints).ApplyNumber(v, instanceID, identityHash, metric, precision, opts)
+}
+
+// InstanceVariationOptions contains timing information used for stateless,
+// time-varying per-instance variation.
+type InstanceVariationOptions struct {
+	Timestamp time.Time
+	StartTime time.Time
+	Interval  time.Duration
 }
 
 // InstanceEmitOptions carries the state needed to emit a data point for one specific instance.
@@ -54,6 +69,7 @@ type InstanceEmitOptions struct {
 	IdentityHash uint64
 	Hints        map[string]MetricGenerationHint
 	Precision    map[string]int
+	Variation    InstanceVariationOptions
 	Rand         *rand.Rand
 	Dist         DistributionCfg
 	ExpHistoGen  *expohistogen.Generator
@@ -64,7 +80,7 @@ type InstanceEmitOptions struct {
 func EmitForInstance(dataPoint dp.DataPoint, metric pmetric.Metric, opts InstanceEmitOptions) {
 	switch v := dataPoint.(type) {
 	case pmetric.NumberDataPoint:
-		ApplyInstanceVariation(v, opts.InstanceID, opts.IdentityHash, metric, opts.Hints, opts.Precision)
+		ApplyInstanceVariation(v, opts.InstanceID, opts.IdentityHash, metric, opts.Hints, opts.Precision, opts.Variation)
 	default:
 		AdvanceDataPoint(dataPoint, opts.Rand, metric, opts.Dist, opts.ExpHistoGen, AdvanceOptions{Precision: opts.Precision})
 	}
@@ -92,7 +108,7 @@ func defaultInstanceVariationFor(metric pmetric.Metric) InstanceVariationStrateg
 
 type noInstanceVariation struct{}
 
-func (noInstanceVariation) ApplyNumber(pmetric.NumberDataPoint, int, uint64, pmetric.Metric, map[string]int) {
+func (noInstanceVariation) ApplyNumber(pmetric.NumberDataPoint, int, uint64, pmetric.Metric, map[string]int, InstanceVariationOptions) {
 }
 
 type boundedMultiplierVariation struct {
@@ -101,13 +117,20 @@ type boundedMultiplierVariation struct {
 	clampUtilization bool
 }
 
-func (s boundedMultiplierVariation) ApplyNumber(v pmetric.NumberDataPoint, instanceID int, identityHash uint64, metric pmetric.Metric, precision map[string]int) {
+func (s boundedMultiplierVariation) ApplyNumber(v pmetric.NumberDataPoint, instanceID int, identityHash uint64, metric pmetric.Metric, precision map[string]int, opts InstanceVariationOptions) {
 	current := currentNumberDataPointValue(v)
 	if current == 0 {
 		return
 	}
-	multiplier := s.min + (s.max-s.min)*hashToUnitInterval(mixInstanceID(identityHash, instanceID))
-	next := math.Max(0, current*multiplier)
+	instanceUnit := hashToUnitInterval(mixInstanceID(identityHash, instanceID))
+	multiplier := s.min + (s.max-s.min)*instanceUnit
+	next := current * multiplier
+	if isCumulativeMonotonicSum(metric) {
+		next += current * counterElapsedMultiplier(instanceUnit, opts)
+	} else {
+		next *= temporalMultiplier(identityHash, instanceID, opts)
+	}
+	next = math.Max(0, next)
 	if s.clampUtilization && strings.HasSuffix(metric.Name(), ".utilization") {
 		next = min(next, 1)
 	}
@@ -119,7 +142,7 @@ type integerOffsetVariation struct {
 	max int64
 }
 
-func (s integerOffsetVariation) ApplyNumber(v pmetric.NumberDataPoint, instanceID int, identityHash uint64, metric pmetric.Metric, precision map[string]int) {
+func (s integerOffsetVariation) ApplyNumber(v pmetric.NumberDataPoint, instanceID int, identityHash uint64, metric pmetric.Metric, precision map[string]int, opts InstanceVariationOptions) {
 	current := currentNumberDataPointValue(v)
 	span := s.max - s.min + 1
 	if span <= 0 {
@@ -129,6 +152,69 @@ func (s integerOffsetVariation) ApplyNumber(v pmetric.NumberDataPoint, instanceI
 	offset := positiveMod(int64(instanceID)+base, span) + s.min
 	next := math.Max(0, current+float64(offset))
 	writeNumberDataPoint(v, next, metric, precision)
+}
+
+func isCumulativeMonotonicSum(metric pmetric.Metric) bool {
+	return metric.Type() == pmetric.MetricTypeSum &&
+		metric.Sum().IsMonotonic() &&
+		metric.Sum().AggregationTemporality() == pmetric.AggregationTemporalityCumulative
+}
+
+func temporalMultiplier(identityHash uint64, instanceID int, opts InstanceVariationOptions) float64 {
+	if opts.Timestamp.IsZero() || opts.Interval <= 0 {
+		return 1
+	}
+	return 1 + gaugeTemporalVariationAmplitude*temporalNoise(identityHash, instanceID, opts)
+}
+
+func counterElapsedMultiplier(instanceUnit float64, opts InstanceVariationOptions) float64 {
+	if opts.Timestamp.IsZero() || opts.StartTime.IsZero() || opts.Interval <= 0 {
+		return 0
+	}
+	elapsed := opts.Timestamp.Sub(opts.StartTime).Seconds() / opts.Interval.Seconds()
+	if elapsed <= 0 {
+		return 0
+	}
+	// Ramp toward a bounded extra multiplier so cumulative counters stay monotonic
+	// without per-series state or a time-varying factor that can shrink.
+	return counterElapsedMultiplierMax * instanceUnit * elapsed / (elapsed + temporalVariationBucketCount)
+}
+
+func temporalNoise(identityHash uint64, instanceID int, opts InstanceVariationOptions) float64 {
+	if opts.Timestamp.IsZero() || opts.Interval <= 0 {
+		return 0
+	}
+	bucketDuration := opts.Interval * temporalVariationBucketCount
+	if bucketDuration <= 0 {
+		return 0
+	}
+	timestamp := opts.Timestamp.UnixNano()
+	bucketNanos := bucketDuration.Nanoseconds()
+	bucket := timestamp / bucketNanos
+	fraction := float64(timestamp%bucketNanos) / float64(bucketNanos)
+	if fraction < 0 {
+		fraction += 1
+		bucket--
+	}
+	start := hashToSignedUnit(temporalBucketHash(identityHash, instanceID, bucket))
+	end := hashToSignedUnit(temporalBucketHash(identityHash, instanceID, bucket+1))
+	return lerp(start, end, smoothstep(fraction))
+}
+
+func temporalBucketHash(identityHash uint64, instanceID int, bucket int64) uint64 {
+	return mixInstanceID(identityHash^uint64(bucket)*0xbf58476d1ce4e5b9, instanceID)
+}
+
+func hashToSignedUnit(hash uint64) float64 {
+	return hashToUnitInterval(hash)*2 - 1
+}
+
+func smoothstep(v float64) float64 {
+	return v * v * (3 - 2*v)
+}
+
+func lerp(start, end, fraction float64) float64 {
+	return start + (end-start)*fraction
 }
 
 func writeNumberDataPoint(v pmetric.NumberDataPoint, next float64, metric pmetric.Metric, precision map[string]int) {

--- a/metricsgenreceiver/internal/distribution/instance_variation_test.go
+++ b/metricsgenreceiver/internal/distribution/instance_variation_test.go
@@ -120,8 +120,9 @@ func TestCounterInstanceVariationKeepsCountersNonNegative(t *testing.T) {
 func TestCumulativeCounterInstanceVariationAddsElapsedRate(t *testing.T) {
 	start := time.Unix(1000, 0)
 	opts := InstanceVariationOptions{
-		StartTime: start,
-		Interval:  30 * time.Second,
+		StartTime:        start,
+		Interval:         30 * time.Second,
+		CounterBaseDelta: 100,
 	}
 	hints := map[string]MetricGenerationHint{
 		"test.steady_counter": {Class: GenerationHintSteadyCounter},
@@ -138,6 +139,25 @@ func TestCumulativeCounterInstanceVariationAddsElapsedRate(t *testing.T) {
 	applyVariationWithOptions(dpB, 7, metricB, hints, opts)
 
 	assert.Greater(t, dpB.DoubleValue(), dpA.DoubleValue())
+}
+
+func TestCumulativeCounterExtraRateDoesNotDecayForLargeSeed(t *testing.T) {
+	start := time.Unix(1000, 0)
+	opts := InstanceVariationOptions{
+		StartTime:        start,
+		Interval:         30 * time.Second,
+		CounterBaseDelta: 100,
+	}
+	hints := map[string]MetricGenerationHint{
+		"test.steady_counter": {Class: GenerationHintSteadyCounter},
+	}
+
+	earlyA := variedCumulativeCounterValue(t, "test.steady_counter", 246011864+100, 7, start.Add(30*time.Second), opts, hints)
+	earlyB := variedCumulativeCounterValue(t, "test.steady_counter", 246011864+200, 7, start.Add(60*time.Second), opts, hints)
+	lateA := variedCumulativeCounterValue(t, "test.steady_counter", 246011864+9900, 7, start.Add(99*30*time.Second), opts, hints)
+	lateB := variedCumulativeCounterValue(t, "test.steady_counter", 246011864+10000, 7, start.Add(100*30*time.Second), opts, hints)
+
+	assert.InDelta(t, earlyB-earlyA, lateB-lateA, 0.000001)
 }
 
 func TestMultiplierVariationKeepsZeroFlat(t *testing.T) {
@@ -219,6 +239,15 @@ func newGaugeDoubleMetric(name string, value float64) (pmetric.Metric, pmetric.N
 	dp := metric.Gauge().DataPoints().AppendEmpty()
 	dp.SetDoubleValue(value)
 	return metric, dp
+}
+
+func variedCumulativeCounterValue(t *testing.T, name string, value float64, instanceID int, timestamp time.Time, opts InstanceVariationOptions, hints map[string]MetricGenerationHint) float64 {
+	t.Helper()
+	metric, dp := newCumulativeDoubleSumMetric(name, value)
+	dp.Attributes().PutStr("device", "sda")
+	opts.Timestamp = timestamp
+	applyVariationWithOptions(dp, instanceID, metric, hints, opts)
+	return dp.DoubleValue()
 }
 
 func newGaugeIntMetric(name string, value int64) (pmetric.Metric, pmetric.NumberDataPoint) {

--- a/metricsgenreceiver/internal/distribution/instance_variation_test.go
+++ b/metricsgenreceiver/internal/distribution/instance_variation_test.go
@@ -1,0 +1,194 @@
+package distribution
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+func applyVariation(v pmetric.NumberDataPoint, instanceID int, metric pmetric.Metric, hints map[string]MetricGenerationHint) {
+	ApplyInstanceVariation(v, instanceID, IdentityHash(metric.Name(), v.Attributes()), metric, hints, nil)
+}
+
+func TestInstanceVariationIsDeterministic(t *testing.T) {
+	hints := map[string]MetricGenerationHint{
+		"system.cpu.utilization": {Class: GenerationHintSlowGauge},
+	}
+
+	metricA, dpA := newGaugeDoubleMetric("system.cpu.utilization", 0.55)
+	dpA.Attributes().PutStr("cpu", "0")
+	dpA.Attributes().PutStr("state", "user")
+	applyVariation(dpA, 7, metricA, hints)
+
+	// Same instance + metric + attrs (in different insertion order) → same output.
+	metricB, dpB := newGaugeDoubleMetric("system.cpu.utilization", 0.55)
+	dpB.Attributes().PutStr("state", "user")
+	dpB.Attributes().PutStr("cpu", "0")
+	applyVariation(dpB, 7, metricB, hints)
+
+	// Different instance ID → different output.
+	metricC, dpC := newGaugeDoubleMetric("system.cpu.utilization", 0.55)
+	dpC.Attributes().PutStr("cpu", "0")
+	dpC.Attributes().PutStr("state", "user")
+	applyVariation(dpC, 8, metricC, hints)
+
+	assert.Equal(t, dpA.DoubleValue(), dpB.DoubleValue())
+	assert.NotEqual(t, dpA.DoubleValue(), dpC.DoubleValue())
+}
+
+func TestCurrentCountInstanceVariationKeepsCountsIntegralAndNonNegative(t *testing.T) {
+	hints := map[string]MetricGenerationHint{
+		"test.current_count": {Class: GenerationHintCurrentCount},
+	}
+
+	metricA, dpA := newGaugeIntMetric("test.current_count", 10)
+	dpA.Attributes().PutStr("queue", "ingest")
+	applyVariation(dpA, 0, metricA, hints)
+
+	metricB, dpB := newGaugeIntMetric("test.current_count", 10)
+	dpB.Attributes().PutStr("queue", "ingest")
+	applyVariation(dpB, 1, metricB, hints)
+
+	assert.NotEqual(t, dpA.IntValue(), dpB.IntValue())
+
+	for _, instanceID := range []int{0, 1, 2, 7, 42} {
+		metric, dp := newGaugeIntMetric("test.current_count", 1)
+		dp.Attributes().PutStr("queue", "ingest")
+		applyVariation(dp, instanceID, metric, hints)
+		assert.GreaterOrEqual(t, dp.IntValue(), int64(0))
+	}
+}
+
+func TestSlowGaugeInstanceVariationKeepsUtilizationBounded(t *testing.T) {
+	hints := map[string]MetricGenerationHint{
+		"system.cpu.utilization": {Class: GenerationHintSlowGauge},
+	}
+	for instanceID := 0; instanceID < 32; instanceID++ {
+		metric, dp := newGaugeDoubleMetric("system.cpu.utilization", 0.99)
+		dp.Attributes().PutStr("cpu", "0")
+		applyVariation(dp, instanceID, metric, hints)
+		assert.GreaterOrEqual(t, dp.DoubleValue(), 0.0)
+		assert.LessOrEqual(t, dp.DoubleValue(), 1.0)
+	}
+}
+
+func TestCounterInstanceVariationKeepsCountersNonNegative(t *testing.T) {
+	hints := map[string]MetricGenerationHint{
+		"test.steady_counter": {Class: GenerationHintSteadyCounter},
+		"test.sparse_counter": {Class: GenerationHintSparseCounter},
+	}
+
+	for _, instanceID := range []int{0, 1, 2, 7, 42} {
+		steadyMetric, steadyDP := newCumulativeDoubleSumMetric("test.steady_counter", 100)
+		steadyDP.Attributes().PutStr("device", "sda")
+		applyVariation(steadyDP, instanceID, steadyMetric, hints)
+		assert.GreaterOrEqual(t, steadyDP.DoubleValue(), 0.0)
+
+		sparseMetric, sparseDP := newCumulativeDoubleSumMetric("test.sparse_counter", 5)
+		sparseDP.Attributes().PutStr("device", "sda")
+		applyVariation(sparseDP, instanceID, sparseMetric, hints)
+		assert.GreaterOrEqual(t, sparseDP.DoubleValue(), 0.0)
+	}
+}
+
+func TestMultiplierVariationKeepsZeroFlat(t *testing.T) {
+	hints := map[string]MetricGenerationHint{
+		"test.sparse_counter": {Class: GenerationHintSparseCounter},
+	}
+	metric, dp := newCumulativeDoubleSumMetric("test.sparse_counter", 0)
+	dp.Attributes().PutStr("device", "sda")
+
+	applyVariation(dp, 99, metric, hints)
+
+	assert.Equal(t, 0.0, dp.DoubleValue())
+}
+
+func TestNoOpInstanceVariationHintsRemainSynchronized(t *testing.T) {
+	tests := []struct {
+		name  string
+		class GenerationHintClass
+		build func() (pmetric.Metric, pmetric.NumberDataPoint)
+		read  func(pmetric.NumberDataPoint) any
+	}{
+		{
+			name:  "constant",
+			class: GenerationHintConstant,
+			build: func() (pmetric.Metric, pmetric.NumberDataPoint) {
+				return newGaugeIntMetric("test.constant", 10)
+			},
+			read: func(dp pmetric.NumberDataPoint) any { return dp.IntValue() },
+		},
+		{
+			name:  "clock",
+			class: GenerationHintClock,
+			build: func() (pmetric.Metric, pmetric.NumberDataPoint) {
+				return newGaugeDoubleMetric("test.clock", 1000)
+			},
+			read: func(dp pmetric.NumberDataPoint) any { return dp.DoubleValue() },
+		},
+		{
+			name:  "stable_binary",
+			class: GenerationHintStableBinary,
+			build: func() (pmetric.Metric, pmetric.NumberDataPoint) {
+				return newGaugeIntMetric("test.stable_binary", 1)
+			},
+			read: func(dp pmetric.NumberDataPoint) any { return dp.IntValue() },
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			hints := map[string]MetricGenerationHint{}
+			metricA, dpA := tc.build()
+			metricB, dpB := tc.build()
+			hints[metricA.Name()] = MetricGenerationHint{Class: tc.class}
+
+			expected := tc.read(dpA)
+			applyVariation(dpA, 0, metricA, hints)
+			applyVariation(dpB, 1, metricB, hints)
+
+			assert.Equal(t, expected, tc.read(dpA))
+			assert.Equal(t, expected, tc.read(dpB))
+		})
+	}
+}
+
+func TestDefaultInstanceVariationForUnhintedMetrics(t *testing.T) {
+	metricA, dpA := newGaugeDoubleMetric("test.unhinted", 50)
+	metricB, dpB := newGaugeDoubleMetric("test.unhinted", 50)
+
+	applyVariation(dpA, 0, metricA, nil)
+	applyVariation(dpB, 1, metricB, nil)
+
+	assert.NotEqual(t, dpA.DoubleValue(), dpB.DoubleValue())
+}
+
+func newGaugeDoubleMetric(name string, value float64) (pmetric.Metric, pmetric.NumberDataPoint) {
+	metric := pmetric.NewMetric()
+	metric.SetName(name)
+	metric.SetEmptyGauge()
+	dp := metric.Gauge().DataPoints().AppendEmpty()
+	dp.SetDoubleValue(value)
+	return metric, dp
+}
+
+func newGaugeIntMetric(name string, value int64) (pmetric.Metric, pmetric.NumberDataPoint) {
+	metric := pmetric.NewMetric()
+	metric.SetName(name)
+	metric.SetEmptyGauge()
+	dp := metric.Gauge().DataPoints().AppendEmpty()
+	dp.SetIntValue(value)
+	return metric, dp
+}
+
+func newCumulativeDoubleSumMetric(name string, value float64) (pmetric.Metric, pmetric.NumberDataPoint) {
+	metric := pmetric.NewMetric()
+	metric.SetName(name)
+	metric.SetEmptySum()
+	metric.Sum().SetIsMonotonic(true)
+	metric.Sum().SetAggregationTemporality(pmetric.AggregationTemporalityCumulative)
+	dp := metric.Sum().DataPoints().AppendEmpty()
+	dp.SetDoubleValue(value)
+	return metric, dp
+}

--- a/metricsgenreceiver/internal/distribution/instance_variation_test.go
+++ b/metricsgenreceiver/internal/distribution/instance_variation_test.go
@@ -65,6 +65,33 @@ func TestCurrentCountInstanceVariationKeepsCountsIntegralAndNonNegative(t *testi
 	}
 }
 
+func TestCurrentCountInstanceVariationChangesOverTimeWithoutState(t *testing.T) {
+	start := time.Unix(1000, 0)
+	opts := InstanceVariationOptions{
+		StartTime: start,
+		Interval:  30 * time.Second,
+	}
+	hints := map[string]MetricGenerationHint{
+		"test.current_count": {Class: GenerationHintCurrentCount},
+	}
+
+	metricA, dpA := newGaugeIntMetric("test.current_count", 10)
+	dpA.Attributes().PutStr("queue", "ingest")
+	opts.Timestamp = start
+	applyVariationWithOptions(dpA, 7, metricA, hints, opts)
+
+	changed := false
+	for i := 1; i <= 20; i++ {
+		metricB, dpB := newGaugeIntMetric("test.current_count", 10)
+		dpB.Attributes().PutStr("queue", "ingest")
+		opts.Timestamp = start.Add(time.Duration(i) * opts.Interval)
+		applyVariationWithOptions(dpB, 7, metricB, hints, opts)
+		changed = changed || dpA.IntValue() != dpB.IntValue()
+	}
+
+	assert.True(t, changed)
+}
+
 func TestSlowGaugeInstanceVariationKeepsUtilizationBounded(t *testing.T) {
 	hints := map[string]MetricGenerationHint{
 		"system.cpu.utilization": {Class: GenerationHintSlowGauge},
@@ -76,6 +103,21 @@ func TestSlowGaugeInstanceVariationKeepsUtilizationBounded(t *testing.T) {
 		assert.GreaterOrEqual(t, dp.DoubleValue(), 0.0)
 		assert.LessOrEqual(t, dp.DoubleValue(), 1.0)
 	}
+}
+
+func TestUnitIntervalGaugeVariationBouncesAtBounds(t *testing.T) {
+	hints := map[string]MetricGenerationHint{
+		"system.cpu.utilization": {Class: GenerationHintSlowGauge},
+	}
+
+	for instanceID := 0; instanceID < 64; instanceID++ {
+		metric, dp := newGaugeDoubleMetric("system.cpu.utilization", 0.99)
+		dp.Attributes().PutStr("cpu", "0")
+		applyVariation(dp, instanceID, metric, hints)
+		assert.GreaterOrEqual(t, dp.DoubleValue(), 0.0)
+		assert.LessOrEqual(t, dp.DoubleValue(), 1.0)
+	}
+	assert.InDelta(t, 0.9, bounceBetweenZeroAndOne(1.1), 0.000001)
 }
 
 func TestGaugeInstanceVariationChangesOverTimeWithoutState(t *testing.T) {

--- a/metricsgenreceiver/internal/distribution/instance_variation_test.go
+++ b/metricsgenreceiver/internal/distribution/instance_variation_test.go
@@ -1,6 +1,7 @@
 package distribution
 
 import (
+	"math"
 	"testing"
 	"time"
 
@@ -140,6 +141,19 @@ func TestGaugeInstanceVariationChangesOverTimeWithoutState(t *testing.T) {
 	assert.NotEqual(t, dpA.DoubleValue(), dpB.DoubleValue())
 }
 
+func TestNonUnitGaugeInstanceVariationDoesNotScaleBelowBaseline(t *testing.T) {
+	opts := InstanceVariationOptions{
+		Timestamp: time.Unix(1000, 0),
+		Interval:  30 * time.Second,
+	}
+
+	for instanceID := 0; instanceID < 128; instanceID++ {
+		metric, dp := newGaugeDoubleMetric("test.unhinted", 1.01)
+		applyVariationWithOptions(dp, instanceID, metric, nil, opts)
+		assert.GreaterOrEqual(t, dp.DoubleValue(), 1.01)
+	}
+}
+
 func TestCounterInstanceVariationKeepsCountersNonNegative(t *testing.T) {
 	hints := map[string]MetricGenerationHint{
 		"test.steady_counter": {Class: GenerationHintSteadyCounter},
@@ -183,7 +197,7 @@ func TestCumulativeCounterInstanceVariationAddsElapsedRate(t *testing.T) {
 	assert.Greater(t, dpB.DoubleValue(), dpA.DoubleValue())
 }
 
-func TestCumulativeCounterExtraRateDoesNotDecayForLargeSeed(t *testing.T) {
+func TestCumulativeCounterExtraRateVariesWithoutDecreasingLargeSeed(t *testing.T) {
 	start := time.Unix(1000, 0)
 	opts := InstanceVariationOptions{
 		StartTime:        start,
@@ -194,12 +208,19 @@ func TestCumulativeCounterExtraRateDoesNotDecayForLargeSeed(t *testing.T) {
 		"test.steady_counter": {Class: GenerationHintSteadyCounter},
 	}
 
-	earlyA := variedCumulativeCounterValue(t, "test.steady_counter", 246011864+100, 7, start.Add(30*time.Second), opts, hints)
-	earlyB := variedCumulativeCounterValue(t, "test.steady_counter", 246011864+200, 7, start.Add(60*time.Second), opts, hints)
-	lateA := variedCumulativeCounterValue(t, "test.steady_counter", 246011864+9900, 7, start.Add(99*30*time.Second), opts, hints)
-	lateB := variedCumulativeCounterValue(t, "test.steady_counter", 246011864+10000, 7, start.Add(100*30*time.Second), opts, hints)
+	prev := variedCumulativeCounterValue(t, "test.steady_counter", 246011864, 7, start, opts, hints)
+	minDelta := math.Inf(1)
+	maxDelta := math.Inf(-1)
+	for i := 1; i <= 100; i++ {
+		current := variedCumulativeCounterValue(t, "test.steady_counter", 246011864+float64(100*i), 7, start.Add(time.Duration(i)*opts.Interval), opts, hints)
+		delta := current - prev
+		assert.Greater(t, delta, 0.0)
+		minDelta = min(minDelta, delta)
+		maxDelta = max(maxDelta, delta)
+		prev = current
+	}
 
-	assert.InDelta(t, earlyB-earlyA, lateB-lateA, 0.000001)
+	assert.Greater(t, maxDelta-minDelta, 1.0)
 }
 
 func TestMultiplierVariationKeepsZeroFlat(t *testing.T) {

--- a/metricsgenreceiver/internal/distribution/instance_variation_test.go
+++ b/metricsgenreceiver/internal/distribution/instance_variation_test.go
@@ -2,13 +2,18 @@ package distribution
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
 func applyVariation(v pmetric.NumberDataPoint, instanceID int, metric pmetric.Metric, hints map[string]MetricGenerationHint) {
-	ApplyInstanceVariation(v, instanceID, IdentityHash(metric.Name(), v.Attributes()), metric, hints, nil)
+	applyVariationWithOptions(v, instanceID, metric, hints, InstanceVariationOptions{})
+}
+
+func applyVariationWithOptions(v pmetric.NumberDataPoint, instanceID int, metric pmetric.Metric, hints map[string]MetricGenerationHint, opts InstanceVariationOptions) {
+	ApplyInstanceVariation(v, instanceID, IdentityHash(metric.Name(), v.Attributes()), metric, hints, nil, opts)
 }
 
 func TestInstanceVariationIsDeterministic(t *testing.T) {
@@ -73,6 +78,26 @@ func TestSlowGaugeInstanceVariationKeepsUtilizationBounded(t *testing.T) {
 	}
 }
 
+func TestGaugeInstanceVariationChangesOverTimeWithoutState(t *testing.T) {
+	start := time.Unix(1000, 0)
+	opts := InstanceVariationOptions{
+		StartTime: start,
+		Interval:  30 * time.Second,
+	}
+
+	metricA, dpA := newGaugeDoubleMetric("test.unhinted", 100)
+	dpA.Attributes().PutStr("state", "used")
+	opts.Timestamp = start
+	applyVariationWithOptions(dpA, 7, metricA, nil, opts)
+
+	metricB, dpB := newGaugeDoubleMetric("test.unhinted", 100)
+	dpB.Attributes().PutStr("state", "used")
+	opts.Timestamp = start.Add(5 * time.Minute)
+	applyVariationWithOptions(dpB, 7, metricB, nil, opts)
+
+	assert.NotEqual(t, dpA.DoubleValue(), dpB.DoubleValue())
+}
+
 func TestCounterInstanceVariationKeepsCountersNonNegative(t *testing.T) {
 	hints := map[string]MetricGenerationHint{
 		"test.steady_counter": {Class: GenerationHintSteadyCounter},
@@ -90,6 +115,29 @@ func TestCounterInstanceVariationKeepsCountersNonNegative(t *testing.T) {
 		applyVariation(sparseDP, instanceID, sparseMetric, hints)
 		assert.GreaterOrEqual(t, sparseDP.DoubleValue(), 0.0)
 	}
+}
+
+func TestCumulativeCounterInstanceVariationAddsElapsedRate(t *testing.T) {
+	start := time.Unix(1000, 0)
+	opts := InstanceVariationOptions{
+		StartTime: start,
+		Interval:  30 * time.Second,
+	}
+	hints := map[string]MetricGenerationHint{
+		"test.steady_counter": {Class: GenerationHintSteadyCounter},
+	}
+
+	metricA, dpA := newCumulativeDoubleSumMetric("test.steady_counter", 1000)
+	dpA.Attributes().PutStr("device", "sda")
+	opts.Timestamp = start
+	applyVariationWithOptions(dpA, 7, metricA, hints, opts)
+
+	metricB, dpB := newCumulativeDoubleSumMetric("test.steady_counter", 1000)
+	dpB.Attributes().PutStr("device", "sda")
+	opts.Timestamp = start.Add(5 * time.Minute)
+	applyVariationWithOptions(dpB, 7, metricB, hints, opts)
+
+	assert.Greater(t, dpB.DoubleValue(), dpA.DoubleValue())
 }
 
 func TestMultiplierVariationKeepsZeroFlat(t *testing.T) {

--- a/metricsgenreceiver/internal/distribution/series_hash.go
+++ b/metricsgenreceiver/internal/distribution/series_hash.go
@@ -1,0 +1,114 @@
+package distribution
+
+import (
+	"encoding/hex"
+	"fmt"
+	"hash/fnv"
+	"sort"
+	"strconv"
+	"strings"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+)
+
+// IdentityHash computes a stable hash for (metric name, attribute set). It does not include the
+// instance identifier, so callers can precompute it once per template data point and reuse it
+// across every instance/interval emission by mixing in the instance ID.
+func IdentityHash(metricName string, attrs pcommon.Map) uint64 {
+	var b strings.Builder
+	b.Grow(64)
+	b.WriteString("metric=")
+	b.WriteString(metricName)
+	appendAttributesKey(&b, attrs)
+	return hashStableKey(b.String())
+}
+
+// mixInstanceID derives a per-instance hash from a precomputed identity hash using a splitmix64-style
+// finalizer. Cheap (a few arithmetic ops) and avalanches well enough for the narrow ranges we map
+// into.
+func mixInstanceID(identityHash uint64, instanceID int) uint64 {
+	h := identityHash ^ uint64(instanceID)*0x9e3779b97f4a7c15
+	h ^= h >> 33
+	h *= 0xff51afd7ed558ccd
+	h ^= h >> 33
+	return h
+}
+
+// hashToUnitInterval maps a uint64 hash into [0, 1) with 53-bit precision (the full mantissa of a
+// float64).
+func hashToUnitInterval(hash uint64) float64 {
+	return float64(hash>>11) * (1.0 / (1 << 53))
+}
+
+func hashStableKey(key string) uint64 {
+	h := fnv.New64a()
+	_, _ = h.Write([]byte(key))
+	return h.Sum64()
+}
+
+func appendAttributesKey(b *strings.Builder, attrs pcommon.Map) {
+	for _, key := range sortedMapKeys(attrs) {
+		value, _ := attrs.Get(key)
+		b.WriteString("|attr=")
+		b.WriteString(key)
+		b.WriteByte(':')
+		appendValueKey(b, value)
+	}
+}
+
+func appendValueKey(b *strings.Builder, value pcommon.Value) {
+	switch value.Type() {
+	case pcommon.ValueTypeEmpty:
+		b.WriteString("empty")
+	case pcommon.ValueTypeStr:
+		b.WriteString("str:")
+		b.WriteString(value.Str())
+	case pcommon.ValueTypeInt:
+		b.WriteString("int:")
+		b.WriteString(strconv.FormatInt(value.Int(), 10))
+	case pcommon.ValueTypeDouble:
+		b.WriteString("double:")
+		b.WriteString(strconv.FormatFloat(value.Double(), 'g', -1, 64))
+	case pcommon.ValueTypeBool:
+		b.WriteString("bool:")
+		b.WriteString(strconv.FormatBool(value.Bool()))
+	case pcommon.ValueTypeBytes:
+		b.WriteString("bytes:")
+		b.WriteString(hex.EncodeToString(value.Bytes().AsRaw()))
+	case pcommon.ValueTypeMap:
+		b.WriteByte('{')
+		nested := value.Map()
+		for i, key := range sortedMapKeys(nested) {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			nestedValue, _ := nested.Get(key)
+			b.WriteString(key)
+			b.WriteByte(':')
+			appendValueKey(b, nestedValue)
+		}
+		b.WriteByte('}')
+	case pcommon.ValueTypeSlice:
+		b.WriteByte('[')
+		values := value.Slice()
+		for i := 0; i < values.Len(); i++ {
+			if i > 0 {
+				b.WriteByte(',')
+			}
+			appendValueKey(b, values.At(i))
+		}
+		b.WriteByte(']')
+	default:
+		panic(fmt.Sprintf("unsupported attribute value type %v", value.Type()))
+	}
+}
+
+func sortedMapKeys(attrs pcommon.Map) []string {
+	keys := make([]string, 0, attrs.Len())
+	attrs.Range(func(k string, _ pcommon.Value) bool {
+		keys = append(keys, k)
+		return true
+	})
+	sort.Strings(keys)
+	return keys
+}

--- a/metricsgenreceiver/internal/dp/datapoint.go
+++ b/metricsgenreceiver/internal/dp/datapoint.go
@@ -21,34 +21,40 @@ func ForEachMetric(ms *pmetric.Metrics, visitor func(res pcommon.Resource, is pc
 	}
 }
 
-func ForEachDataPoint(ms *pmetric.Metrics, visitor func(res pcommon.Resource, is pcommon.InstrumentationScope, m pmetric.Metric, dp DataPoint)) {
+func ForEachDataPoint(ms *pmetric.Metrics, visitor func(index int, res pcommon.Resource, is pcommon.InstrumentationScope, m pmetric.Metric, dp DataPoint)) {
+	index := 0
 	ForEachMetric(ms, func(res pcommon.Resource, is pcommon.InstrumentationScope, m pmetric.Metric) {
 		//exhaustive:enforce
 		switch m.Type() {
 		case pmetric.MetricTypeGauge:
 			ds := m.Gauge().DataPoints()
 			for l := 0; l < ds.Len(); l++ {
-				visitor(res, is, m, ds.At(l))
+				visitor(index, res, is, m, ds.At(l))
+				index++
 			}
 		case pmetric.MetricTypeSum:
 			ds := m.Sum().DataPoints()
 			for l := 0; l < ds.Len(); l++ {
-				visitor(res, is, m, ds.At(l))
+				visitor(index, res, is, m, ds.At(l))
+				index++
 			}
 		case pmetric.MetricTypeHistogram:
 			ds := m.Histogram().DataPoints()
 			for l := 0; l < ds.Len(); l++ {
-				visitor(res, is, m, ds.At(l))
+				visitor(index, res, is, m, ds.At(l))
+				index++
 			}
 		case pmetric.MetricTypeExponentialHistogram:
 			ds := m.ExponentialHistogram().DataPoints()
 			for l := 0; l < ds.Len(); l++ {
-				visitor(res, is, m, ds.At(l))
+				visitor(index, res, is, m, ds.At(l))
+				index++
 			}
 		case pmetric.MetricTypeSummary:
 			ds := m.Summary().DataPoints()
 			for l := 0; l < ds.Len(); l++ {
-				visitor(res, is, m, ds.At(l))
+				visitor(index, res, is, m, ds.At(l))
+				index++
 			}
 		case pmetric.MetricTypeEmpty:
 		}

--- a/metricsgenreceiver/internal/dp/datapoint_test.go
+++ b/metricsgenreceiver/internal/dp/datapoint_test.go
@@ -1,0 +1,52 @@
+package dp
+
+import (
+	"reflect"
+	"testing"
+
+	"go.opentelemetry.io/collector/pdata/pcommon"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+)
+
+func TestForEachDataPointIndexes(t *testing.T) {
+	metrics := pmetric.NewMetrics()
+	scopeMetrics := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty()
+
+	gauge := scopeMetrics.Metrics().AppendEmpty()
+	gauge.SetName("gauge")
+	gauge.SetEmptyGauge().DataPoints().AppendEmpty()
+	gauge.Gauge().DataPoints().AppendEmpty()
+
+	sum := scopeMetrics.Metrics().AppendEmpty()
+	sum.SetName("sum")
+	sum.SetEmptySum().DataPoints().AppendEmpty()
+
+	histogram := scopeMetrics.Metrics().AppendEmpty()
+	histogram.SetName("histogram")
+	histogram.SetEmptyHistogram().DataPoints().AppendEmpty()
+
+	exponentialHistogram := scopeMetrics.Metrics().AppendEmpty()
+	exponentialHistogram.SetName("exponential_histogram")
+	exponentialHistogram.SetEmptyExponentialHistogram().DataPoints().AppendEmpty()
+
+	summary := scopeMetrics.Metrics().AppendEmpty()
+	summary.SetName("summary")
+	summary.SetEmptySummary().DataPoints().AppendEmpty()
+
+	var indexes []int
+	var metricNames []string
+	ForEachDataPoint(&metrics, func(index int, _ pcommon.Resource, _ pcommon.InstrumentationScope, metric pmetric.Metric, _ DataPoint) {
+		indexes = append(indexes, index)
+		metricNames = append(metricNames, metric.Name())
+	})
+
+	expectedIndexes := []int{0, 1, 2, 3, 4, 5}
+	if !reflect.DeepEqual(expectedIndexes, indexes) {
+		t.Fatalf("expected indexes %v, got %v", expectedIndexes, indexes)
+	}
+
+	expectedMetricNames := []string{"gauge", "gauge", "sum", "histogram", "exponential_histogram", "summary"}
+	if !reflect.DeepEqual(expectedMetricNames, metricNames) {
+		t.Fatalf("expected metric names %v, got %v", expectedMetricNames, metricNames)
+	}
+}

--- a/metricsgenreceiver/internal/expohistogen/expohistogen.go
+++ b/metricsgenreceiver/internal/expohistogen/expohistogen.go
@@ -252,7 +252,7 @@ func extractExponentialHistograms(jsonBytes []byte) ([]pmetric.ExponentialHistog
 	var dataPoints []pmetric.ExponentialHistogramDataPoint
 
 	// Use ForEachDataPoint to iterate through all data points
-	dp.ForEachDataPoint(&metrics, func(_ pcommon.Resource, _ pcommon.InstrumentationScope, m pmetric.Metric, dataPoint dp.DataPoint) {
+	dp.ForEachDataPoint(&metrics, func(_ int, _ pcommon.Resource, _ pcommon.InstrumentationScope, m pmetric.Metric, dataPoint dp.DataPoint) {
 		if m.Type() == pmetric.MetricTypeExponentialHistogram && m.ExponentialHistogram().AggregationTemporality() == pmetric.AggregationTemporalityDelta {
 			// Type assert to get the exponential histogram data point
 			if expHistDP, ok := dataPoint.(pmetric.ExponentialHistogramDataPoint); ok {

--- a/metricsgenreceiver/receiver.go
+++ b/metricsgenreceiver/receiver.go
@@ -372,9 +372,10 @@ func (r *MetricsGenReceiver) produceMetricsForInstance(ctx context.Context, rng 
 			Hints:        scn.generationHints,
 			Precision:    scn.precision,
 			Variation: distribution.InstanceVariationOptions{
-				Timestamp: currentTime,
-				StartTime: r.cfg.StartTime,
-				Interval:  r.cfg.Interval,
+				Timestamp:        currentTime,
+				StartTime:        r.cfg.StartTime,
+				Interval:         r.cfg.Interval,
+				CounterBaseDelta: float64(r.cfg.Distribution.MedianMonotonicSum),
 			},
 			Rand:        rng,
 			Dist:        r.cfg.Distribution,

--- a/metricsgenreceiver/receiver.go
+++ b/metricsgenreceiver/receiver.go
@@ -42,9 +42,18 @@ type Scenario struct {
 	config                     ScenarioCfg
 	metricsTemplate            *pmetric.Metrics
 	resourceAttributesTemplate pcommon.Resource
-	resources                  []pcommon.Resource
+	instances                  []scenarioInstance
 	precision                  map[string]int
 	generationHints            map[string]distribution.MetricGenerationHint
+	// seriesIdentityHashes holds IdentityHash(metric name, attrs) for each template data point in
+	// the order ForEachDataPoint visits them. Precomputed once so the per-instance emission path
+	// avoids re-hashing the attribute set on every tick.
+	seriesIdentityHashes []uint64
+}
+
+type scenarioInstance struct {
+	id       int
+	resource pcommon.Resource
 }
 
 type MetricsProgress struct {
@@ -140,12 +149,24 @@ func newMetricsGenReceiver(cfg *Config, set receiver.Settings) (*MetricsGenRecei
 		if err != nil {
 			return nil, err
 		}
+		instances := make([]scenarioInstance, len(resources))
+		for i, resource := range resources {
+			instances[i] = scenarioInstance{
+				id:       i + int(cfg.InstanceOffset),
+				resource: resource,
+			}
+		}
+		var seriesIdentityHashes []uint64
+		dp.ForEachDataPoint(&metrics, func(_ pcommon.Resource, _ pcommon.InstrumentationScope, m pmetric.Metric, dataPoint dp.DataPoint) {
+			seriesIdentityHashes = append(seriesIdentityHashes, distribution.IdentityHash(m.Name(), dataPoint.Attributes()))
+		})
 		scenarios = append(scenarios, Scenario{
-			config:          scn,
-			metricsTemplate: &metrics,
-			resources:       resources,
-			precision:       distribution.InferPrecision(&metrics),
-			generationHints: generationHints,
+			config:               scn,
+			metricsTemplate:      &metrics,
+			instances:            instances,
+			precision:            distribution.InferPrecision(&metrics),
+			generationHints:      generationHints,
+			seriesIdentityHashes: seriesIdentityHashes,
 		})
 	}
 
@@ -279,7 +300,10 @@ func (r *MetricsGenReceiver) applyChurn(interval int, simulatedTime time.Time) {
 			if err != nil {
 				r.settings.Logger.Error("failed to apply churn", zap.Error(err))
 			} else {
-				scn.resources[id%len(scn.resources)] = resource
+				scn.instances[id%len(scn.instances)] = scenarioInstance{
+					id:       id + int(r.cfg.InstanceOffset),
+					resource: resource,
+				}
 			}
 		}
 	}
@@ -304,8 +328,8 @@ func (r *MetricsGenReceiver) produceMetrics(ctx context.Context, currentTime tim
 			distribution.AdvanceDataPoint(dataPoint, r.baseRand, m, r.cfg.Distribution, r.expHistoGen, opts)
 		})
 		if scn.config.Concurrency == 0 {
-			for i := range scn.config.Scale {
-				*dataPoints += uint64(r.produceMetricsForInstance(ctx, r.baseRand, currentTime, scn, scn.resources[i]))
+			for i := range scn.instances {
+				*dataPoints += uint64(r.produceMetricsForInstance(ctx, r.baseRand, currentTime, scn, scn.instances[i]))
 			}
 			continue
 		}
@@ -318,8 +342,8 @@ func (r *MetricsGenReceiver) produceMetrics(ctx context.Context, currentTime tim
 			go func() {
 				defer wg.Done()
 				for j := 0; j < scn.config.Scale/scn.config.Concurrency; j++ {
-					resource := scn.resources[j+i*scn.config.Scale/scn.config.Concurrency]
-					currentDataPoints := r.produceMetricsForInstance(ctx, rng, currentTime, scn, resource)
+					instance := scn.instances[j+i*scn.config.Scale/scn.config.Concurrency]
+					currentDataPoints := r.produceMetricsForInstance(ctx, rng, currentTime, scn, instance)
 					atomic.AddUint64(dataPoints, uint64(currentDataPoints))
 				}
 			}()
@@ -329,24 +353,30 @@ func (r *MetricsGenReceiver) produceMetrics(ctx context.Context, currentTime tim
 	return *dataPoints
 }
 
-func (r *MetricsGenReceiver) produceMetricsForInstance(ctx context.Context, rng *rand.Rand, currentTime time.Time, scn Scenario, instanceResource pcommon.Resource) int {
+func (r *MetricsGenReceiver) produceMetricsForInstance(ctx context.Context, rng *rand.Rand, currentTime time.Time, scn Scenario, instance scenarioInstance) int {
 	r.obsreport.StartMetricsOp(ctx)
 	metrics := pmetric.NewMetrics()
 	scn.metricsTemplate.CopyTo(metrics)
 	resourceMetrics := metrics.ResourceMetrics()
 	for j := 0; j < resourceMetrics.Len(); j++ {
-		overrideExistingAttributes(instanceResource, resourceMetrics.At(j).Resource())
+		overrideExistingAttributes(instance.resource, resourceMetrics.At(j).Resource())
 	}
 
 	instanceTime := addJitter(currentTime, r.cfg.IntervalJitterStdDev, r.cfg.Interval, rng)
 
+	idx := 0
 	dp.ForEachDataPoint(&metrics, func(res pcommon.Resource, is pcommon.InstrumentationScope, m pmetric.Metric, dataPoint dp.DataPoint) {
-		if _, ok := scn.generationHints[m.Name()]; !ok {
-			distribution.AdvanceDataPoint(dataPoint, rng, m, r.cfg.Distribution, r.expHistoGen, distribution.AdvanceOptions{
-				Precision: scn.precision,
-			})
-		}
+		distribution.EmitForInstance(dataPoint, m, distribution.InstanceEmitOptions{
+			InstanceID:   instance.id,
+			IdentityHash: scn.seriesIdentityHashes[idx],
+			Hints:        scn.generationHints,
+			Precision:    scn.precision,
+			Rand:         rng,
+			Dist:         r.cfg.Distribution,
+			ExpHistoGen:  r.expHistoGen,
+		})
 		dataPoint.SetTimestamp(pcommon.NewTimestampFromTime(instanceTime))
+		idx++
 	})
 	dataPoints := metrics.DataPointCount()
 	err := r.nextMetrics.ConsumeMetrics(ctx, metrics)

--- a/metricsgenreceiver/receiver.go
+++ b/metricsgenreceiver/receiver.go
@@ -126,7 +126,7 @@ func newMetricsGenReceiver(cfg *Config, set receiver.Settings) (*MetricsGenRecei
 				replaceHistogramsWithExponentialHistograms(m)
 			})
 		}
-		dp.ForEachDataPoint(&metrics, func(res pcommon.Resource, is pcommon.InstrumentationScope, m pmetric.Metric, dp dp.DataPoint) {
+		dp.ForEachDataPoint(&metrics, func(_ int, res pcommon.Resource, is pcommon.InstrumentationScope, m pmetric.Metric, dp dp.DataPoint) {
 			dp.SetStartTimestamp(pcommon.NewTimestampFromTime(cfg.StartTime))
 			if scn.AggregationTemporalityOverride() != pmetric.AggregationTemporalityUnspecified {
 				switch m.Type() {
@@ -156,9 +156,9 @@ func newMetricsGenReceiver(cfg *Config, set receiver.Settings) (*MetricsGenRecei
 				resource: resource,
 			}
 		}
-		var seriesIdentityHashes []uint64
-		dp.ForEachDataPoint(&metrics, func(_ pcommon.Resource, _ pcommon.InstrumentationScope, m pmetric.Metric, dataPoint dp.DataPoint) {
-			seriesIdentityHashes = append(seriesIdentityHashes, distribution.IdentityHash(m.Name(), dataPoint.Attributes()))
+		seriesIdentityHashes := make([]uint64, metrics.DataPointCount())
+		dp.ForEachDataPoint(&metrics, func(idx int, _ pcommon.Resource, _ pcommon.InstrumentationScope, m pmetric.Metric, dataPoint dp.DataPoint) {
+			seriesIdentityHashes[idx] = distribution.IdentityHash(m.Name(), dataPoint.Attributes())
 		})
 		scenarios = append(scenarios, Scenario{
 			config:               scn,
@@ -317,7 +317,7 @@ func (r *MetricsGenReceiver) produceMetrics(ctx context.Context, currentTime tim
 		// we don't keep track of the data points for each instance individually to reduce memory pressure
 		// we still advance the metrics template have a new baseline that's used when simulating the metrics for each individual instance
 		// this makes sure counters are increasing over time
-		dp.ForEachDataPoint(scn.metricsTemplate, func(res pcommon.Resource, is pcommon.InstrumentationScope, m pmetric.Metric, dataPoint dp.DataPoint) {
+		dp.ForEachDataPoint(scn.metricsTemplate, func(_ int, res pcommon.Resource, is pcommon.InstrumentationScope, m pmetric.Metric, dataPoint dp.DataPoint) {
 			opts := distribution.AdvanceOptions{
 				Interval:  r.cfg.Interval,
 				Precision: scn.precision,
@@ -364,8 +364,7 @@ func (r *MetricsGenReceiver) produceMetricsForInstance(ctx context.Context, rng 
 
 	instanceTime := addJitter(currentTime, r.cfg.IntervalJitterStdDev, r.cfg.Interval, rng)
 
-	idx := 0
-	dp.ForEachDataPoint(&metrics, func(res pcommon.Resource, is pcommon.InstrumentationScope, m pmetric.Metric, dataPoint dp.DataPoint) {
+	dp.ForEachDataPoint(&metrics, func(idx int, res pcommon.Resource, is pcommon.InstrumentationScope, m pmetric.Metric, dataPoint dp.DataPoint) {
 		distribution.EmitForInstance(dataPoint, m, distribution.InstanceEmitOptions{
 			InstanceID:   instance.id,
 			IdentityHash: scn.seriesIdentityHashes[idx],
@@ -382,7 +381,6 @@ func (r *MetricsGenReceiver) produceMetricsForInstance(ctx context.Context, rng 
 			ExpHistoGen: r.expHistoGen,
 		})
 		dataPoint.SetTimestamp(pcommon.NewTimestampFromTime(instanceTime))
-		idx++
 	})
 	dataPoints := metrics.DataPointCount()
 	err := r.nextMetrics.ConsumeMetrics(ctx, metrics)

--- a/metricsgenreceiver/receiver.go
+++ b/metricsgenreceiver/receiver.go
@@ -371,9 +371,14 @@ func (r *MetricsGenReceiver) produceMetricsForInstance(ctx context.Context, rng 
 			IdentityHash: scn.seriesIdentityHashes[idx],
 			Hints:        scn.generationHints,
 			Precision:    scn.precision,
-			Rand:         rng,
-			Dist:         r.cfg.Distribution,
-			ExpHistoGen:  r.expHistoGen,
+			Variation: distribution.InstanceVariationOptions{
+				Timestamp: currentTime,
+				StartTime: r.cfg.StartTime,
+				Interval:  r.cfg.Interval,
+			},
+			Rand:        rng,
+			Dist:        r.cfg.Distribution,
+			ExpHistoGen: r.expHistoGen,
 		})
 		dataPoint.SetTimestamp(pcommon.NewTimestampFromTime(instanceTime))
 		idx++

--- a/metricsgenreceiver/receiver_test.go
+++ b/metricsgenreceiver/receiver_test.go
@@ -247,7 +247,7 @@ func TestReceiverAppliesGenerationHints(t *testing.T) {
 
 func verifyMetrics(t *testing.T, offset int, cfg *Config, allMetrics []pmetric.Metrics, timestamp time.Time) {
 	for i := offset; i < cfg.Scenarios[0].Scale+offset; i++ {
-		dp.ForEachDataPoint(&allMetrics[i], func(r pcommon.Resource, s pcommon.InstrumentationScope, m pmetric.Metric, dp dp.DataPoint) {
+		dp.ForEachDataPoint(&allMetrics[i], func(_ int, r pcommon.Resource, s pcommon.InstrumentationScope, m pmetric.Metric, dp dp.DataPoint) {
 			r.Attributes().Range(func(k string, v pcommon.Value) bool {
 				require.NotEmpty(t, k)
 				require.NotEmpty(t, v)
@@ -591,15 +591,15 @@ func TestRealtimeTimestampsTrackWallClock(t *testing.T) {
 		metricTimestamp time.Time
 	}
 	var (
-		mu   sync.Mutex
-		obs  []observation
+		mu  sync.Mutex
+		obs []observation
 	)
 
 	consumer := &timestampRecordingConsumer{
 		onConsume: func(md pmetric.Metrics) {
 			wall := time.Now()
 			var metricTs time.Time
-			dp.ForEachDataPoint(&md, func(_ pcommon.Resource, _ pcommon.InstrumentationScope, _ pmetric.Metric, d dp.DataPoint) {
+			dp.ForEachDataPoint(&md, func(_ int, _ pcommon.Resource, _ pcommon.InstrumentationScope, _ pmetric.Metric, d dp.DataPoint) {
 				if metricTs.IsZero() {
 					metricTs = d.Timestamp().AsTime()
 				}

--- a/metricsgenreceiver/receiver_test.go
+++ b/metricsgenreceiver/receiver_test.go
@@ -162,6 +162,89 @@ func TestReceiver(t *testing.T) {
 	}
 }
 
+func TestReceiverAppliesGenerationHints(t *testing.T) {
+	sink := new(consumertest.MetricsSink)
+
+	factory := NewFactory()
+	cfg := testdataConfigYamlAsMap()
+	cfg.Scenarios[0].Path = "testdata/generation-hints-template"
+	cfg.Scenarios[0].Scale = 2
+
+	rcv, err := factory.CreateMetrics(context.Background(), receivertest.NewNopSettings(typ), cfg, sink)
+	require.NoError(t, err)
+	err = rcv.Start(context.Background(), nil)
+	require.NoError(t, err)
+
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		require.Equal(c, 7*2*cfg.Scenarios[0].Scale, sink.DataPointCount())
+	}, 2*time.Second, time.Millisecond)
+	require.NoError(t, rcv.Shutdown(context.Background()))
+
+	allMetrics := sink.AllMetrics()
+	require.Len(t, allMetrics, 4)
+
+	firstIntervalHost0 := allMetrics[0]
+	firstIntervalHost1 := allMetrics[1]
+	secondIntervalHost0 := allMetrics[2]
+	secondIntervalHost1 := allMetrics[3]
+
+	// constant: identical across hosts and intervals.
+	assert.Equal(t, metricIntValue(t, firstIntervalHost0, "test.constant"), metricIntValue(t, secondIntervalHost0, "test.constant"))
+	assert.Equal(t, metricIntValue(t, firstIntervalHost0, "test.constant"), metricIntValue(t, firstIntervalHost1, "test.constant"))
+
+	// clock: identical across hosts, advances by the collection interval.
+	assert.Equal(t, metricDoubleValue(t, firstIntervalHost0, "test.clock"), metricDoubleValue(t, firstIntervalHost1, "test.clock"))
+	assert.Equal(t, metricDoubleValue(t, secondIntervalHost0, "test.clock"), metricDoubleValue(t, secondIntervalHost1, "test.clock"))
+	assert.Equal(t, 30.0, metricDoubleValue(t, secondIntervalHost0, "test.clock")-metricDoubleValue(t, firstIntervalHost0, "test.clock"))
+
+	// stable_binary: identical across hosts and intervals, normalized to 0 or 1.
+	assert.Equal(t, int64(1), metricIntValue(t, firstIntervalHost0, "test.stable_binary"))
+	assert.Equal(t, int64(1), metricIntValue(t, firstIntervalHost1, "test.stable_binary"))
+	assert.Equal(t, int64(1), metricIntValue(t, secondIntervalHost0, "test.stable_binary"))
+	assert.Equal(t, int64(1), metricIntValue(t, secondIntervalHost1, "test.stable_binary"))
+
+	// current_count: varies per instance via a stable integer offset.
+	firstCountHost0 := metricIntValue(t, firstIntervalHost0, "test.current_count")
+	firstCountHost1 := metricIntValue(t, firstIntervalHost1, "test.current_count")
+	secondCountHost0 := metricIntValue(t, secondIntervalHost0, "test.current_count")
+	secondCountHost1 := metricIntValue(t, secondIntervalHost1, "test.current_count")
+	assert.NotEqual(t, firstCountHost0, firstCountHost1)
+	assert.NotEqual(t, secondCountHost0, secondCountHost1)
+	assert.GreaterOrEqual(t, firstCountHost0, int64(0))
+	assert.GreaterOrEqual(t, firstCountHost1, int64(0))
+
+	// slow_gauge.utilization: varies per instance via a stable multiplier, stays within [0, 1].
+	firstSlowGaugeHost0 := metricDoubleValue(t, firstIntervalHost0, "test.slow_gauge.utilization")
+	firstSlowGaugeHost1 := metricDoubleValue(t, firstIntervalHost1, "test.slow_gauge.utilization")
+	assert.NotEqual(t, firstSlowGaugeHost0, firstSlowGaugeHost1)
+	for _, v := range []float64{
+		firstSlowGaugeHost0,
+		firstSlowGaugeHost1,
+		metricDoubleValue(t, secondIntervalHost0, "test.slow_gauge.utilization"),
+		metricDoubleValue(t, secondIntervalHost1, "test.slow_gauge.utilization"),
+	} {
+		assert.GreaterOrEqual(t, v, 0.0)
+		assert.LessOrEqual(t, v, 1.0)
+	}
+
+	// steady_counter: varies per instance, grows monotonically per instance, and preserves relative ordering across intervals.
+	firstCounterHost0 := metricDoubleValue(t, firstIntervalHost0, "test.steady_counter")
+	firstCounterHost1 := metricDoubleValue(t, firstIntervalHost1, "test.steady_counter")
+	secondCounterHost0 := metricDoubleValue(t, secondIntervalHost0, "test.steady_counter")
+	secondCounterHost1 := metricDoubleValue(t, secondIntervalHost1, "test.steady_counter")
+	assert.NotEqual(t, firstCounterHost0, firstCounterHost1)
+	assert.Greater(t, secondCounterHost0, firstCounterHost0)
+	assert.Greater(t, secondCounterHost1, firstCounterHost1)
+	assert.True(t,
+		(firstCounterHost0 < firstCounterHost1) == (secondCounterHost0 < secondCounterHost1),
+		"relative ordering between instances should stay stable across intervals")
+
+	// unhinted gauge: still receives per-instance variation via the default strategy.
+	firstUnhintedHost0 := metricDoubleValue(t, firstIntervalHost0, "test.unhinted")
+	firstUnhintedHost1 := metricDoubleValue(t, firstIntervalHost1, "test.unhinted")
+	assert.NotEqual(t, firstUnhintedHost0, firstUnhintedHost1)
+}
+
 func verifyMetrics(t *testing.T, offset int, cfg *Config, allMetrics []pmetric.Metrics, timestamp time.Time) {
 	for i := offset; i < cfg.Scenarios[0].Scale+offset; i++ {
 		dp.ForEachDataPoint(&allMetrics[i], func(r pcommon.Resource, s pcommon.InstrumentationScope, m pmetric.Metric, dp dp.DataPoint) {
@@ -635,57 +718,6 @@ func collectHostNames(allMetrics []pmetric.Metrics) []string {
 	return hosts
 }
 
-func TestReceiverAppliesGenerationHints(t *testing.T) {
-	sink := new(consumertest.MetricsSink)
-
-	factory := NewFactory()
-	cfg := testdataConfigYamlAsMap()
-	cfg.Scenarios[0].Path = "testdata/generation-hints-template"
-	cfg.Scenarios[0].Scale = 2
-
-	rcv, err := factory.CreateMetrics(context.Background(), receivertest.NewNopSettings(typ), cfg, sink)
-	require.NoError(t, err)
-	err = rcv.Start(context.Background(), nil)
-	require.NoError(t, err)
-
-	require.EventuallyWithT(t, func(c *assert.CollectT) {
-		require.Equal(c, 5*2*cfg.Scenarios[0].Scale, sink.DataPointCount())
-	}, 2*time.Second, time.Millisecond)
-	require.NoError(t, rcv.Shutdown(context.Background()))
-
-	allMetrics := sink.AllMetrics()
-	require.Len(t, allMetrics, 4)
-
-	firstIntervalHost0 := allMetrics[0]
-	firstIntervalHost1 := allMetrics[1]
-	secondIntervalHost0 := allMetrics[2]
-	secondIntervalHost1 := allMetrics[3]
-
-	// constant: identical across hosts and intervals.
-	assert.Equal(t, metricIntValue(t, firstIntervalHost0, "test.constant"), metricIntValue(t, secondIntervalHost0, "test.constant"))
-	assert.Equal(t, metricIntValue(t, firstIntervalHost0, "test.constant"), metricIntValue(t, firstIntervalHost1, "test.constant"))
-
-	// clock: identical across hosts, advances by the collection interval.
-	assert.Equal(t, metricDoubleValue(t, firstIntervalHost0, "test.clock"), metricDoubleValue(t, firstIntervalHost1, "test.clock"))
-	assert.Equal(t, metricDoubleValue(t, secondIntervalHost0, "test.clock"), metricDoubleValue(t, secondIntervalHost1, "test.clock"))
-	assert.Equal(t, 30.0, metricDoubleValue(t, secondIntervalHost0, "test.clock")-metricDoubleValue(t, firstIntervalHost0, "test.clock"))
-
-	// stable_binary: identical across hosts and intervals, normalized to 0 or 1.
-	assert.Equal(t, int64(1), metricIntValue(t, firstIntervalHost0, "test.stable_binary"))
-	assert.Equal(t, int64(1), metricIntValue(t, firstIntervalHost1, "test.stable_binary"))
-	assert.Equal(t, int64(1), metricIntValue(t, secondIntervalHost0, "test.stable_binary"))
-	assert.Equal(t, int64(1), metricIntValue(t, secondIntervalHost1, "test.stable_binary"))
-
-	// current_count: moves in small integer steps. With hints declared, instances share the same template-advanced value.
-	firstCount := metricIntValue(t, firstIntervalHost0, "test.current_count")
-	secondCount := metricIntValue(t, secondIntervalHost0, "test.current_count")
-	assert.Equal(t, firstCount, metricIntValue(t, firstIntervalHost1, "test.current_count"))
-	assert.Equal(t, secondCount, metricIntValue(t, secondIntervalHost1, "test.current_count"))
-	assert.GreaterOrEqual(t, firstCount, int64(0))
-	assert.GreaterOrEqual(t, secondCount, int64(0))
-	assert.LessOrEqual(t, absInt64(secondCount-firstCount), int64(3))
-}
-
 func metricIntValue(t *testing.T, metrics pmetric.Metrics, metricName string) int64 {
 	t.Helper()
 
@@ -730,11 +762,4 @@ func metricDoubleValue(t *testing.T, metrics pmetric.Metrics, metricName string)
 	})
 	require.True(t, found, "metric %q not found", metricName)
 	return value
-}
-
-func absInt64(v int64) int64 {
-	if v < 0 {
-		return -v
-	}
-	return v
 }

--- a/metricsgenreceiver/testdata/generation-hints-template.json
+++ b/metricsgenreceiver/testdata/generation-hints-template.json
@@ -95,6 +95,48 @@
               ]
             },
             {
+              "name": "test.slow_gauge.utilization",
+              "gauge": {
+                "dataPoints": [
+                  {
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0",
+                    "asDouble": 0.5555
+                  }
+                ]
+              },
+              "metadata": [
+                {
+                  "key": "metricsgen.hint.class",
+                  "value": {
+                    "stringValue": "slow_gauge"
+                  }
+                }
+              ]
+            },
+            {
+              "name": "test.steady_counter",
+              "sum": {
+                "aggregationTemporality": 2,
+                "isMonotonic": true,
+                "dataPoints": [
+                  {
+                    "startTimeUnixNano": "0",
+                    "timeUnixNano": "0",
+                    "asDouble": 100
+                  }
+                ]
+              },
+              "metadata": [
+                {
+                  "key": "metricsgen.hint.class",
+                  "value": {
+                    "stringValue": "steady_counter"
+                  }
+                }
+              ]
+            },
+            {
               "name": "test.unhinted",
               "gauge": {
                 "dataPoints": [


### PR DESCRIPTION
## Motivation

The framework in #41 has a hidden trade-off: declaring a generation hint on a metric causes the per-instance emission pass to be skipped entirely. The intent was to preserve the hint's semantics (a `constant` shouldn't drift, a `clock` shouldn't double-tick), but the side effect is that **every simulated host reports bit-identical values** for any hinted metric. A scenario with `scale: 100` and a well-annotated template ends up looking like 100 perfectly-synchronised clones — which both misrepresents real telemetry and gives compression an artificially easy benchmark.

The fix is to make per-instance variation a first-class, deterministic feature instead of an opt-out side effect: each (instance ID × metric × attributes) combination gets its own stable offset or multiplier derived from a hash, so instances differ realistically while each individual instance's series stays coherent across intervals.

## Summary

- **Deterministic per-series variation.** A splitmix64-style mix of a precomputed series identity hash and the instance ID produces a stable `[0, 1)` draw per data point, which is then mapped to either an integer offset (`current_count`) or a bounded multiplier (`slow_gauge`, `sparse_counter`, `steady_counter`, default). Classes that must stay identical across instances (`constant`, `clock`, `stable_binary`) opt out explicitly.
- **Bounded memory.** The identity hash `IdentityHash(metric name, attributes)` is computed once per template data point at startup and stored in `Scenario.seriesIdentityHashes`; the per-tick emission path only does a handful of arithmetic ops to mix in the instance ID. Memory is O(template), not O(template × instances).
- **Single dispatch point.** Replaces the previous hint-presence branch in `produceMetricsForInstance` with a single `distribution.EmitForInstance` call. NumberDataPoints take the deterministic path; histograms keep the existing rng-based advance.
- `TestReceiverAppliesGenerationHints` is extended to assert per-instance spread for `current_count`, `slow_gauge`, `steady_counter`, and the unhinted default, plus time-coherence for `steady_counter`.

## Relationship to other PRs

Stacked on top of #41 (framework), which this PR needs for the hint class definitions and the `generationHints` map in `Scenario`. Not dependent on #42 — the per-instance behaviour is exercised against the testdata fixtures rather than the built-in templates.

## Test plan

- [ ] `make test` passes.
- [ ] Per-instance spread: host0 and host1 report different `current_count`, `slow_gauge.utilization`, `steady_counter` values.
- [ ] Time coherence: per-instance offsets stay stable across intervals (counters preserve host-to-host ordering; utilization stays in [0, 1]).
- [ ] Determinism: `TestInstanceVariationIsDeterministic` confirms attribute-order independence and instance-ID sensitivity.