### PR TITLE
fix(tests): update scenario quality callback signature

### DIFF
--- a/metricsgenreceiver/internal/metricstmpl/scenario_quality_test.go
+++ b/metricsgenreceiver/internal/metricstmpl/scenario_quality_test.go
@@ -157,7 +157,7 @@ func TestBuiltInScenariosDoNotContainDuplicateSeries(t *testing.T) {
 			require.NoError(t, err)
 
 			seen := map[string]struct{}{}
-			dp.ForEachDataPoint(&metrics, func(res pcommon.Resource, _ pcommon.InstrumentationScope, m pmetric.Metric, dataPoint dp.DataPoint) {
+			dp.ForEachDataPoint(&metrics, func(_ int, res pcommon.Resource, _ pcommon.InstrumentationScope, m pmetric.Metric, dataPoint dp.DataPoint) {
 				key := dataPointSeriesKey(m.Name(), res.Attributes(), dataPoint.Attributes())
 				if _, ok := seen[key]; ok {
 					t.Errorf("duplicate metric series %s", key)


### PR DESCRIPTION
## Summary
- Updates the built-in scenario duplicate-series test callback to accept the new data point index argument.
- Restores `make test` on `main` after the merged PRs changed `dp.ForEachDataPoint`.

## Test plan
- `make test`
- `make build`