### PR TITLE
Support sample-based churn configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -151,6 +151,7 @@ receivers:
         * `{{.RandomIntn <n>}}` (a random integer in the range `[0, n)`)
         * `{{.Mod <x> <y>}}` (the result of `x % y`)
   * `churn`: allows to simulate instances spinning down and other instances taking their place, which will create new time series.
+    This is a breaking change for existing configs that used the previous integer `churn` value.
     Replacement is deterministic and round-robin, so time series are replaced gradually instead of all at once.
     During startup, the initially created time series may have fewer samples because churn begins after the first emission.
     Configure either `samples_per_series` or `instance_lifetime`, but not both.

--- a/README.md
+++ b/README.md
@@ -150,7 +150,17 @@ receivers:
         * `{{.ModFrom <n> <list>}}` (an element from the list at index `n % len(list)`)
         * `{{.RandomIntn <n>}}` (a random integer in the range `[0, n)`)
         * `{{.Mod <x> <y>}}` (the result of `x % y`)
-  * `churn` (default 0): allows to simulate instances spinning down and other instances taking their place, which will create new time series.
+  * `churn`: allows to simulate instances spinning down and other instances taking their place, which will create new time series.
+    Replacement is deterministic and round-robin, so time series are replaced gradually instead of all at once.
+    During startup, the initially created time series may have fewer samples because churn begins after the first emission.
+    Configure either `samples_per_series` or `instance_lifetime`, but not both.
+    * `samples_per_series`: the exact number of samples each new time series should emit before its instance is replaced.
+      For example, with `samples_per_series: 6`, each new time series gets 6 samples.
+      Must be greater than or equal to `1`.
+    * `instance_lifetime`: the average lifetime of an active instance.
+      Use this when you want to describe churn as a duration instead of a sample count.
+      This does not guarantee an exact number of samples per time series.
+      Must be greater than or equal to `interval`.
     Time series churn may have an impact on the performance of the backend.
   * `template_vars`: the `<path>.json`/`<path>.yaml` file is rendered as a template.
     This option lets you specify variables that are available during template rendering.

--- a/metricsgenreceiver/config.go
+++ b/metricsgenreceiver/config.go
@@ -50,7 +50,7 @@ type churnRate struct {
 }
 
 func (r churnRate) enabled() bool {
-	return r.intervals != 0
+	return r.replacements > 0 && r.intervals > 0
 }
 
 func newChurnRate(churn *ChurnCfg, scale int, interval time.Duration) churnRate {
@@ -65,6 +65,10 @@ func newChurnRate(churn *ChurnCfg, scale int, interval time.Duration) churnRate 
 }
 
 func reduceChurnRate(replacements, intervals int64) churnRate {
+	if replacements <= 0 || intervals <= 0 {
+		return churnRate{}
+	}
+
 	// Keep the accumulator denominator small without changing the replacement rate.
 	divisor := gcdInt64(replacements, intervals)
 	return churnRate{

--- a/metricsgenreceiver/config.go
+++ b/metricsgenreceiver/config.go
@@ -31,10 +31,53 @@ type ScenarioCfg struct {
 	Path                string         `mapstructure:"path"`
 	Scale               int            `mapstructure:"scale"`
 	Concurrency         int            `mapstructure:"concurrency"`
-	Churn               int            `mapstructure:"churn"`
+	Churn               *ChurnCfg      `mapstructure:"churn"`
 	TemplateVars        map[string]any `mapstructure:"template_vars"`
 	TemporalityOverride string         `mapstructure:"temporality_override"`
 	HistogramOverride   string         `mapstructure:"histogram_override"`
+}
+
+type ChurnCfg struct {
+	InstanceLifetime time.Duration `mapstructure:"instance_lifetime"`
+	SamplesPerSeries int           `mapstructure:"samples_per_series"`
+}
+
+// churnRate is the number of instance replacements to apply per collection interval.
+// It is stored as a fraction so sub-interval replacement rates can accumulate exactly.
+type churnRate struct {
+	replacements int64
+	intervals    int64
+}
+
+func (r churnRate) enabled() bool {
+	return r.intervals != 0
+}
+
+func newChurnRate(churn *ChurnCfg, scale int, interval time.Duration) churnRate {
+	if churn == nil {
+		return churnRate{}
+	}
+	if churn.SamplesPerSeries > 0 {
+		return reduceChurnRate(int64(scale), int64(churn.SamplesPerSeries))
+	}
+
+	return reduceChurnRate(int64(scale)*int64(interval), int64(churn.InstanceLifetime))
+}
+
+func reduceChurnRate(replacements, intervals int64) churnRate {
+	// Keep the accumulator denominator small without changing the replacement rate.
+	divisor := gcdInt64(replacements, intervals)
+	return churnRate{
+		replacements: replacements / divisor,
+		intervals:    intervals / divisor,
+	}
+}
+
+func gcdInt64(a, b int64) int64 {
+	for b != 0 {
+		a, b = b, a%b
+	}
+	return a
 }
 
 func (c ScenarioCfg) AggregationTemporalityOverride() pmetric.AggregationTemporality {
@@ -90,6 +133,29 @@ func (cfg *Config) Validate() error {
 		}
 		if scn.Concurrency < 0 {
 			return fmt.Errorf("concurrency must be a positive number")
+		}
+		if scn.Churn == nil {
+			continue
+		}
+		if scn.Scale <= 0 {
+			return fmt.Errorf("scale must be positive when churn is enabled")
+		}
+		hasInstanceLifetime := scn.Churn.InstanceLifetime != 0
+		hasSamplesPerSeries := scn.Churn.SamplesPerSeries != 0
+		if hasInstanceLifetime == hasSamplesPerSeries {
+			return fmt.Errorf("exactly one of churn.samples_per_series or churn.instance_lifetime must be set")
+		}
+		if hasSamplesPerSeries && scn.Churn.SamplesPerSeries < 1 {
+			return fmt.Errorf("churn.samples_per_series must be greater than or equal to 1")
+		}
+		if !hasInstanceLifetime {
+			continue
+		}
+		if scn.Churn.InstanceLifetime < 0 {
+			return fmt.Errorf("churn.instance_lifetime must be a positive duration")
+		}
+		if scn.Churn.InstanceLifetime < cfg.Interval {
+			return fmt.Errorf("churn.instance_lifetime must be greater than or equal to interval")
 		}
 	}
 	return nil

--- a/metricsgenreceiver/config_test.go
+++ b/metricsgenreceiver/config_test.go
@@ -149,6 +149,12 @@ func TestConfigValidateChurn(t *testing.T) {
 	}
 }
 
+func TestNewChurnRateIgnoresInvalidZeroValues(t *testing.T) {
+	assert.False(t, newChurnRate(&ChurnCfg{}, 0, time.Second).enabled())
+	assert.False(t, newChurnRate(&ChurnCfg{SamplesPerSeries: 1}, 0, time.Second).enabled())
+	assert.False(t, newChurnRate(&ChurnCfg{InstanceLifetime: time.Second}, 1, 0).enabled())
+}
+
 func TestConfig_ExponentialHistogramsTemplatePath(t *testing.T) {
 	t.Run("custom path", func(t *testing.T) {
 		cfg := &Config{

--- a/metricsgenreceiver/config_test.go
+++ b/metricsgenreceiver/config_test.go
@@ -48,6 +48,107 @@ func testdataConfigYamlAsMap() *Config {
 	}
 }
 
+func TestConfigValidateChurn(t *testing.T) {
+	tests := []struct {
+		name      string
+		scenario  ScenarioCfg
+		wantError string
+	}{
+		{
+			name: "churn instance lifetime",
+			scenario: ScenarioCfg{
+				Scale: 10,
+				Churn: &ChurnCfg{
+					InstanceLifetime: time.Minute,
+				},
+			},
+		},
+		{
+			name: "churn samples per series",
+			scenario: ScenarioCfg{
+				Scale: 10,
+				Churn: &ChurnCfg{
+					SamplesPerSeries: 6,
+				},
+			},
+		},
+		{
+			name: "churn requires scale",
+			scenario: ScenarioCfg{
+				Churn: &ChurnCfg{
+					InstanceLifetime: time.Minute,
+				},
+			},
+			wantError: "scale must be positive when churn is enabled",
+		},
+		{
+			name: "churn requires instance lifetime",
+			scenario: ScenarioCfg{
+				Scale: 10,
+				Churn: &ChurnCfg{},
+			},
+			wantError: "exactly one of churn.samples_per_series or churn.instance_lifetime must be set",
+		},
+		{
+			name: "churn samples per series and instance lifetime are mutually exclusive",
+			scenario: ScenarioCfg{
+				Scale: 10,
+				Churn: &ChurnCfg{
+					InstanceLifetime: time.Minute,
+					SamplesPerSeries: 6,
+				},
+			},
+			wantError: "exactly one of churn.samples_per_series or churn.instance_lifetime must be set",
+		},
+		{
+			name: "negative samples per series",
+			scenario: ScenarioCfg{
+				Scale: 10,
+				Churn: &ChurnCfg{
+					SamplesPerSeries: -1,
+				},
+			},
+			wantError: "churn.samples_per_series must be greater than or equal to 1",
+		},
+		{
+			name: "negative instance lifetime",
+			scenario: ScenarioCfg{
+				Scale: 10,
+				Churn: &ChurnCfg{
+					InstanceLifetime: -time.Minute,
+				},
+			},
+			wantError: "churn.instance_lifetime must be a positive duration",
+		},
+		{
+			name: "instance lifetime shorter than interval",
+			scenario: ScenarioCfg{
+				Scale: 10,
+				Churn: &ChurnCfg{
+					InstanceLifetime: 500 * time.Millisecond,
+				},
+			},
+			wantError: "churn.instance_lifetime must be greater than or equal to interval",
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			cfg := &Config{
+				Interval:  time.Second,
+				Scenarios: []ScenarioCfg{tc.scenario},
+			}
+
+			err := cfg.Validate()
+			if tc.wantError == "" {
+				require.NoError(t, err)
+			} else {
+				require.EqualError(t, err, tc.wantError)
+			}
+		})
+	}
+}
+
 func TestConfig_ExponentialHistogramsTemplatePath(t *testing.T) {
 	t.Run("custom path", func(t *testing.T) {
 		cfg := &Config{

--- a/metricsgenreceiver/receiver.go
+++ b/metricsgenreceiver/receiver.go
@@ -295,7 +295,7 @@ func addJitter(t time.Time, stdDev time.Duration, interval time.Duration, ra *ra
 func (r *MetricsGenReceiver) applyChurn(simulatedTime time.Time) {
 	for idx := range r.scenarios {
 		scn := &r.scenarios[idx]
-		churn := r.churnCount(scn)
+		churn := r.advanceChurnCount(scn)
 		if churn == 0 || len(scn.instances) == 0 {
 			continue
 		}
@@ -317,7 +317,7 @@ func (r *MetricsGenReceiver) applyChurn(simulatedTime time.Time) {
 	}
 }
 
-func (r *MetricsGenReceiver) churnCount(scn *Scenario) int {
+func (r *MetricsGenReceiver) advanceChurnCount(scn *Scenario) int {
 	if !scn.churnRate.enabled() {
 		return 0
 	}

--- a/metricsgenreceiver/receiver.go
+++ b/metricsgenreceiver/receiver.go
@@ -295,7 +295,7 @@ func addJitter(t time.Time, stdDev time.Duration, interval time.Duration, ra *ra
 func (r *MetricsGenReceiver) applyChurn(simulatedTime time.Time) {
 	for idx := range r.scenarios {
 		scn := &r.scenarios[idx]
-		churn := r.advanceChurnCount(scn)
+		churn := r.consumeNextChurnCount(scn)
 		if churn == 0 || len(scn.instances) == 0 {
 			continue
 		}
@@ -317,7 +317,7 @@ func (r *MetricsGenReceiver) applyChurn(simulatedTime time.Time) {
 	}
 }
 
-func (r *MetricsGenReceiver) advanceChurnCount(scn *Scenario) int {
+func (r *MetricsGenReceiver) consumeNextChurnCount(scn *Scenario) int {
 	if !scn.churnRate.enabled() {
 		return 0
 	}

--- a/metricsgenreceiver/receiver.go
+++ b/metricsgenreceiver/receiver.go
@@ -45,6 +45,9 @@ type Scenario struct {
 	instances                  []scenarioInstance
 	precision                  map[string]int
 	generationHints            map[string]distribution.MetricGenerationHint
+	nextReplacementInstanceID  int
+	churnRate                  churnRate
+	churnRemainder             int64
 	// seriesIdentityHashes holds IdentityHash(metric name, attrs) for each template data point in
 	// the order ForEachDataPoint visits them. Precomputed once so the per-instance emission path
 	// avoids re-hashing the attribute set on every tick.
@@ -161,12 +164,14 @@ func newMetricsGenReceiver(cfg *Config, set receiver.Settings) (*MetricsGenRecei
 			seriesIdentityHashes[idx] = distribution.IdentityHash(m.Name(), dataPoint.Attributes())
 		})
 		scenarios = append(scenarios, Scenario{
-			config:               scn,
-			metricsTemplate:      &metrics,
-			instances:            instances,
-			precision:            distribution.InferPrecision(&metrics),
-			generationHints:      generationHints,
-			seriesIdentityHashes: seriesIdentityHashes,
+			config:                    scn,
+			metricsTemplate:           &metrics,
+			instances:                 instances,
+			precision:                 distribution.InferPrecision(&metrics),
+			generationHints:           generationHints,
+			nextReplacementInstanceID: scn.Scale,
+			churnRate:                 newChurnRate(scn.Churn, scn.Scale, cfg.Interval),
+			seriesIdentityHashes:      seriesIdentityHashes,
 		})
 	}
 
@@ -206,7 +211,7 @@ func (r *MetricsGenReceiver) Start(ctx context.Context, host component.Host) err
 				nextLog = nextLog.Add(10 * time.Second)
 			}
 			r.progress.datapoints.Add(r.produceMetrics(ctx, currentTime))
-			r.applyChurn(i, currentTime)
+			r.applyChurn(currentTime)
 
 			if r.cfg.RealTime {
 				select {
@@ -287,15 +292,18 @@ func addJitter(t time.Time, stdDev time.Duration, interval time.Duration, ra *ra
 	return t.Add(jitter)
 }
 
-func (r *MetricsGenReceiver) applyChurn(interval int, simulatedTime time.Time) {
-	for _, scn := range r.scenarios {
-		if scn.config.Churn == 0 {
+func (r *MetricsGenReceiver) applyChurn(simulatedTime time.Time) {
+	for idx := range r.scenarios {
+		scn := &r.scenarios[idx]
+		churn := r.churnCount(scn)
+		if churn == 0 || len(scn.instances) == 0 {
 			continue
 		}
 
 		startTime := simulatedTime.Format(time.RFC3339)
-		for i := 0; i < scn.config.Churn; i++ {
-			id := scn.config.Scale + interval*scn.config.Churn + i
+		for i := 0; i < churn; i++ {
+			id := scn.nextReplacementInstanceID
+			scn.nextReplacementInstanceID++
 			resource, err := metricstmpl.RenderResource(scn.config.Path, id, startTime, scn.config.TemplateVars, r.baseRand, r.cfg.InstanceOffset)
 			if err != nil {
 				r.settings.Logger.Error("failed to apply churn", zap.Error(err))
@@ -307,6 +315,18 @@ func (r *MetricsGenReceiver) applyChurn(interval int, simulatedTime time.Time) {
 			}
 		}
 	}
+}
+
+func (r *MetricsGenReceiver) churnCount(scn *Scenario) int {
+	if !scn.churnRate.enabled() {
+		return 0
+	}
+
+	// Carry the fractional remainder forward so slower churn rates are spread across intervals.
+	scn.churnRemainder += scn.churnRate.replacements
+	churn := scn.churnRemainder / scn.churnRate.intervals
+	scn.churnRemainder %= scn.churnRate.intervals
+	return int(churn)
 }
 
 func (r *MetricsGenReceiver) produceMetrics(ctx context.Context, currentTime time.Time) uint64 {

--- a/metricsgenreceiver/receiver_test.go
+++ b/metricsgenreceiver/receiver_test.go
@@ -695,6 +695,79 @@ func TestRealtimeShutdownCompletesPromptly(t *testing.T) {
 		"Shutdown stalled - goroutine was not unblocked by context cancellation")
 }
 
+func TestSamplesPerSeriesChurnsRoundRobin(t *testing.T) {
+	startTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	cfg := &Config{
+		StartTime: startTime,
+		EndTime:   startTime.Add(5 * time.Second),
+		Interval:  time.Second,
+		Seed:      42,
+		Scenarios: []ScenarioCfg{{
+			Path:  "builtin/simple",
+			Scale: 3,
+			Churn: &ChurnCfg{
+				SamplesPerSeries: 3,
+			},
+			TemplateVars: map[string]any{"gauge_pct": 1, "gauge_int": 0, "counter": 0},
+		}},
+	}
+	rcv, err := newMetricsGenReceiver(cfg, receivertest.NewNopSettings(typ))
+	require.NoError(t, err)
+
+	require.Equal(t, []string{"host-0", "host-1", "host-2"}, instanceHostNames(rcv.scenarios[0].instances))
+
+	rcv.applyChurn(startTime)
+	require.Equal(t, []string{"host-3", "host-1", "host-2"}, instanceHostNames(rcv.scenarios[0].instances))
+
+	rcv.applyChurn(startTime.Add(time.Second))
+	require.Equal(t, []string{"host-3", "host-4", "host-2"}, instanceHostNames(rcv.scenarios[0].instances))
+
+	rcv.applyChurn(startTime.Add(2 * time.Second))
+	require.Equal(t, []string{"host-3", "host-4", "host-5"}, instanceHostNames(rcv.scenarios[0].instances))
+}
+
+func TestInstanceLifetimeSupportsLessThanOneReplacementPerInterval(t *testing.T) {
+	startTime := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	cfg := &Config{
+		StartTime: startTime,
+		EndTime:   startTime.Add(5 * time.Second),
+		Interval:  time.Second,
+		Seed:      42,
+		Scenarios: []ScenarioCfg{{
+			Path:  "builtin/simple",
+			Scale: 4,
+			Churn: &ChurnCfg{
+				InstanceLifetime: 8 * time.Second,
+			},
+			TemplateVars: map[string]any{"gauge_pct": 1, "gauge_int": 0, "counter": 0},
+		}},
+	}
+	rcv, err := newMetricsGenReceiver(cfg, receivertest.NewNopSettings(typ))
+	require.NoError(t, err)
+
+	rcv.applyChurn(startTime)
+	require.Equal(t, []string{"host-0", "host-1", "host-2", "host-3"}, instanceHostNames(rcv.scenarios[0].instances))
+
+	rcv.applyChurn(startTime.Add(time.Second))
+	require.Equal(t, []string{"host-4", "host-1", "host-2", "host-3"}, instanceHostNames(rcv.scenarios[0].instances))
+
+	rcv.applyChurn(startTime.Add(2 * time.Second))
+	require.Equal(t, []string{"host-4", "host-1", "host-2", "host-3"}, instanceHostNames(rcv.scenarios[0].instances))
+
+	rcv.applyChurn(startTime.Add(3 * time.Second))
+	require.Equal(t, []string{"host-4", "host-5", "host-2", "host-3"}, instanceHostNames(rcv.scenarios[0].instances))
+}
+
+func instanceHostNames(instances []scenarioInstance) []string {
+	hosts := make([]string, 0, len(instances))
+	for _, instance := range instances {
+		if host, ok := instance.resource.Attributes().Get("host.name"); ok {
+			hosts = append(hosts, host.Str())
+		}
+	}
+	return hosts
+}
+
 func collectHostNames(allMetrics []pmetric.Metrics) []string {
 	hostSet := make(map[string]bool)
 


### PR DESCRIPTION
We want to introduce realistic levels of time series churn into benchmarking without making churn behavior depend on a fixed number of replacements per interval. This change replaces the old churn count with configuration that can express either an exact `samples_per_series` target or an average `instance_lifetime`, giving benchmark configs finer granularity and a more direct mental model for how long each generated series should live.

At runtime the receiver converts the selected option into a deterministic replacement rate and applies it round-robin, so replacements are spread across intervals instead of all active series changing at once. The README documents the startup caveat and the mutually exclusive churn options.