### PR TITLE
fix(config): update Elasticsearch exporter examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,7 +5,7 @@ otelcol-dev
 ocb
 
 # Ignore the development config file
-otelcol.dev.yaml
+otelcol.dev*.yaml
 
 # Ignore .DS_Store files
 .DS_Store

--- a/README.md
+++ b/README.md
@@ -206,23 +206,3 @@ service:
       receivers: [metricsgen]
       exporters: [nop]
 ```
-
-### Exporter settings
-
-Multiple exporter settings are already in the default config. Adjust the outputs needed. In case the metricsgenreceiver is sending data to a stack setup with elastic-package, the following exporter config
-for Elasticsearch has to be used (assuming it runs on localhost):
-
-```
-exporters:
-  elasticsearch:
-    endpoint: "https://localhost:9200"
-    mapping:
-      mode: otel
-    metrics_dynamic_index:
-      enabled: true
-    num_workers: 10
-    user: elastic
-    password: changeme
-    tls:
-      insecure_skip_verify: true
-```

--- a/otelcol.yaml
+++ b/otelcol.yaml
@@ -43,48 +43,71 @@ receivers:
 #        counter: 1
 #        gauge_pct: 0
 #        gauge_int: 0
-
-processors:
-  batch:
+#    - path: builtin/node_exporter
+#      scale: 100
 
 extensions:
-  pprof:
+  basicauth/client:
+    client_auth:
+      username: elastic
+      password: password
 
 exporters:
-  debug:
-    verbosity: detailed
-  file:
-    path: ./file-exporter/metrics-generated.json
-  nop:
-  otlphttp/victoriametrics:
-    compression: gzip
-    encoding: proto
-    endpoint: http://localhost:8428/opentelemetry
+  elasticsearch:
+    endpoint: http://localhost:9200
     sending_queue:
       enabled: true
-      block_on_overflow: true
-      queue_size: 10
       num_consumers: 10
-  prometheusremotewrite/victoriametrics:
-    endpoint: "http://localhost:8428/api/v1/write"
+      sizer: bytes
+      queue_size: 50_000_000
+      block_on_overflow: true
+      batch:
+        flush_timeout: 1s
+        min_size: 1_000_000
+        max_size: 4_000_000
+  elasticsearch/elastic-package:
+    endpoint: https://localhost:9200
+    user: elastic
+    password: changeme
+    tls:
+      insecure_skip_verify: true
+    sending_queue:
+      enabled: true
+      num_consumers: 10
+      sizer: bytes
+      queue_size: 50_000_000
+      block_on_overflow: true
+      batch:
+        flush_timeout: 1s
+        min_size: 1_000_000
+        max_size: 4_000_000
+  otlphttp/elasticsearch:
+    compression: gzip
+    endpoint: http://localhost:9200/_otlp
+    #headers:
+    #  Authorization: ApiKey <key>
+    sending_queue:
+      enabled: true
+      num_consumers: 10
+      sizer: bytes
+      queue_size: 50_000_000
+      block_on_overflow: true
+      batch:
+        flush_timeout: 1s
+        min_size: 1_000_000
+        max_size: 4_000_000
+  prometheusremotewrite/elasticsearch:
+    endpoint: https://localhost:9200/_prometheus/api/v1/write
     resource_to_telemetry_conversion:
       enabled: true
-    remote_write_queue:
+    target_info:
       enabled: false
-  elasticsearch:
-    endpoint: "http://localhost:9200"
-    mapping:
-      mode: otel
-    metrics_dynamic_index:
-      enabled: true
-    num_workers: 10
+    remote_write_queue:
+      num_consumers: 10
 
 service:
-#  extensions: [pprof]
   pipelines:
     metrics:
       receivers: [metricsgen]
-      processors: [batch]
-#      exporters: [nop]
-#      exporters: [elasticsearch] # do not use with batch processor. ES exporter is doing batching internally.
-      exporters: [otlphttp/victoriametrics] # only use with batch processor
+#      exporters: [elasticsearch/elastic-package]
+      exporters: [otlphttp/elasticsearch]


### PR DESCRIPTION
This updates the sample collector configuration for the Elasticsearch exporter changes discussed in #46. The default `otelcol.yaml` now uses supported `sending_queue` settings instead of the deprecated worker-based configuration, keeps the OTLP/HTTP Elasticsearch path aligned with the same queue tuning, and includes a named `elasticsearch/elastic-package` example for local elastic-package stacks.

The README no longer carries a separate elastic-package exporter block, so the checked-in collector example is the single place to adjust those exporter variants. I also broadened the local development config ignore rule so ad hoc `otelcol.dev*.yaml` files stay out of commits.

I validated the updated default config with `./otelcol-dev/otelcol validate --config otelcol.yaml` and ran `make test`.