### PR TITLE
chore(ci): automate OTel Collector dependency bumps and releases

### DIFF
--- a/.github/updatecli/updatecli.d/otel-collector.yaml
+++ b/.github/updatecli/updatecli.d/otel-collector.yaml
@@ -1,0 +1,91 @@
+name: Bump OpenTelemetry Collector
+
+scms:
+  default:
+    kind: github
+    spec:
+      user: github-actions[bot]
+      email: 41898282+github-actions[bot]@users.noreply.github.com
+      owner: elastic
+      repository: metricsgenreceiver
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      branch: main
+
+sources:
+  collector:
+    kind: githubrelease
+    spec:
+      owner: open-telemetry
+      repository: opentelemetry-collector-releases
+      token: '{{ requiredEnv "GITHUB_TOKEN" }}'
+      username: '{{ requiredEnv "GITHUB_ACTOR" }}'
+      versionfilter:
+        kind: regex/semver
+        regex: '^cmd/builder/v(0\.[0-9]+\.[0-9]+)$'
+        pattern: '*'
+
+targets:
+  builder-config:
+    name: Bump builder config to v{{ source "collector" }}
+    kind: file
+    scmid: default
+    sourceid: collector
+    spec:
+      file: builder-config.yaml
+      matchpattern: '0\.[0-9]+\.[0-9]+'
+
+  ci-builder:
+    name: Bump CI builder to v{{ source "collector" }}
+    kind: file
+    scmid: default
+    sourceid: collector
+    spec:
+      file: .github/workflows/ci.yaml
+      matchpattern: '0\.[0-9]+\.[0-9]+'
+
+  makefile-ocb:
+    name: Bump Makefile OCB to v{{ source "collector" }}
+    kind: file
+    scmid: default
+    sourceid: collector
+    spec:
+      file: Makefile
+      matchpattern: '0\.[0-9]+\.[0-9]+'
+
+  readme-ocb:
+    name: Bump README OCB to v{{ source "collector" }}
+    kind: file
+    scmid: default
+    sourceid: collector
+    spec:
+      file: README.md
+      matchpattern: '0\.[0-9]+\.[0-9]+'
+
+  go-mod:
+    name: Bump Go modules to v{{ source "collector" }}
+    kind: shell
+    scmid: default
+    sourceid: collector
+    spec:
+      command: >-
+        bash -ec 'version="v$1"; cd metricsgenreceiver; go get
+        go.opentelemetry.io/collector/component@latest
+        go.opentelemetry.io/collector/confmap@latest
+        go.opentelemetry.io/collector/consumer@latest
+        go.opentelemetry.io/collector/pdata@latest
+        go.opentelemetry.io/collector/receiver@latest
+        go.opentelemetry.io/collector/component/componentstatus@"$version"
+        go.opentelemetry.io/collector/component/componenttest@"$version"
+        go.opentelemetry.io/collector/confmap/xconfmap@"$version"
+        go.opentelemetry.io/collector/consumer/consumertest@"$version"
+        go.opentelemetry.io/collector/receiver/receiverhelper@"$version"
+        go.opentelemetry.io/collector/receiver/receivertest@"$version";
+        go mod tidy; cd ..; git diff --quiet -- metricsgenreceiver/go.mod
+        metricsgenreceiver/go.sum || echo "updated Go modules to $version"' _
+
+actions:
+  default:
+    kind: github/pullrequest
+    scmid: default
+    title: 'chore(deps): bump OpenTelemetry Collector to v{{ source "collector" }}'

--- a/.github/updatecli/updatecli.d/otel-collector.yaml
+++ b/.github/updatecli/updatecli.d/otel-collector.yaml
@@ -22,7 +22,7 @@ sources:
       username: '{{ requiredEnv "GITHUB_ACTOR" }}'
       versionfilter:
         kind: regex/semver
-        regex: '^cmd/builder/v(0\.[0-9]+\.[0-9]+)$'
+        regex: '^cmd/builder/v([0-9]+\.[0-9]+\.[0-9]+)$'
         pattern: '*'
 
 targets:
@@ -33,7 +33,7 @@ targets:
     sourceid: collector
     spec:
       file: builder-config.yaml
-      matchpattern: '0\.[0-9]+\.[0-9]+'
+      matchpattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
   ci-builder:
     name: Bump CI builder to v{{ source "collector" }}
@@ -42,7 +42,8 @@ targets:
     sourceid: collector
     spec:
       file: .github/workflows/ci.yaml
-      matchpattern: '0\.[0-9]+\.[0-9]+'
+      matchpattern: '(run:\s+go install go\.opentelemetry\.io/collector/cmd/builder@v)[0-9]+\.[0-9]+\.[0-9]+'
+      replacepattern: '${1}{{ source "collector" }}'
 
   makefile-ocb:
     name: Bump Makefile OCB to v{{ source "collector" }}
@@ -51,7 +52,7 @@ targets:
     sourceid: collector
     spec:
       file: Makefile
-      matchpattern: '0\.[0-9]+\.[0-9]+'
+      matchpattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
   readme-ocb:
     name: Bump README OCB to v{{ source "collector" }}
@@ -60,7 +61,7 @@ targets:
     sourceid: collector
     spec:
       file: README.md
-      matchpattern: '0\.[0-9]+\.[0-9]+'
+      matchpattern: '[0-9]+\.[0-9]+\.[0-9]+'
 
   go-mod:
     name: Bump Go modules to v{{ source "collector" }}

--- a/.github/updatecli/updatecli.d/otel-collector.yaml
+++ b/.github/updatecli/updatecli.d/otel-collector.yaml
@@ -52,7 +52,8 @@ targets:
     sourceid: collector
     spec:
       file: Makefile
-      matchpattern: '[0-9]+\.[0-9]+\.[0-9]+'
+      matchpattern: '(OCB_VERSION\s+\?=\s+)[0-9]+\.[0-9]+\.[0-9]+'
+      replacepattern: '${1}{{ source "collector" }}'
 
   readme-ocb:
     name: Bump README OCB to v{{ source "collector" }}

--- a/.github/workflows/tag-otel-bump.yaml
+++ b/.github/workflows/tag-otel-bump.yaml
@@ -21,7 +21,10 @@ jobs:
           token: ${{ secrets.RELEASE_BOT_TOKEN }}
 
       - run: |
-          latest=$(git tag -l 'v1.0.*' --sort=-v:refname | sed -n '1p')
-          next="v1.0.$((${latest##*.} + 1))"
+          latest=$(git tag -l 'v*.*.*' --sort=-v:refname | sed -n '1p')
+          test -n "$latest"
+          major_minor=${latest%.*}
+          patch=${latest##*.}
+          next="${major_minor}.$((patch + 1))"
           git tag "$next"
           git push origin "$next"

--- a/.github/workflows/tag-otel-bump.yaml
+++ b/.github/workflows/tag-otel-bump.yaml
@@ -1,0 +1,27 @@
+name: Tag OTel Bump
+
+on:
+  pull_request:
+    branches: [ main ]
+    types: [ closed ]
+
+permissions:
+  contents: write
+
+jobs:
+  tag:
+    if: >-
+      github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, 'chore(deps): bump OpenTelemetry Collector to v')
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+          fetch-depth: 0
+          token: ${{ secrets.RELEASE_BOT_TOKEN }}
+
+      - run: |
+          latest=$(git tag -l 'v1.0.*' --sort=-v:refname | sed -n '1p')
+          next="v1.0.$((${latest##*.} + 1))"
+          git tag "$next"
+          git push origin "$next"

--- a/.github/workflows/update-otel-collector.yaml
+++ b/.github/workflows/update-otel-collector.yaml
@@ -1,0 +1,26 @@
+name: Update OTel Collector
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '37 6 * * 1-5'
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  updatecli:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: metricsgenreceiver/go.mod
+
+      - uses: updatecli/updatecli-action@v2
+
+      - run: updatecli apply --config .github/updatecli/updatecli.d/otel-collector.yaml
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,6 @@
 # This currently only works for OS X ARM64.
+OCB_VERSION ?= 0.139.0
+
 .PHONY: test
 test:
 	cd metricsgenreceiver && go test ./...
@@ -6,7 +8,7 @@ test:
 .PHONY: install-ocb
 install-ocb:
 	curl --proto '=https' --tlsv1.2 -fL -o ocb \
-	https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/cmd%2Fbuilder%2Fv0.139.0/ocb_0.139.0_darwin_arm64
+	https://github.com/open-telemetry/opentelemetry-collector-releases/releases/download/cmd%2Fbuilder%2Fv$(OCB_VERSION)/ocb_$(OCB_VERSION)_darwin_arm64
 	chmod +x ocb
 
 .PHONY: build


### PR DESCRIPTION
## Summary
   
- Add an Updatecli pipeline that sources the latest stable OTel Collector release via a `cmd/builder/v*` semver filter and opens a bump PR using version-agnostic regex match patterns across all targets.
- Update version pins in builder config, CI workflow, README, Makefile (extracted to an `OCB_VERSION` variable), and Go modules (`go get` + `mod tidy`) through the Updatecli run.
 - Add a scheduled workflow (weekdays) to run Updatecli, and a post-merge workflow that auto-tags merged bump PRs by incrementing the patch of the latest existing semver tag.