### PR TITLE
chore(ci): fix OTel Collector bump automation

### DIFF
--- a/.github/updatecli/updatecli.d/otel-collector.yaml
+++ b/.github/updatecli/updatecli.d/otel-collector.yaml
@@ -24,6 +24,8 @@ sources:
         kind: regex/semver
         regex: '^cmd/builder/v([0-9]+\.[0-9]+\.[0-9]+)$'
         pattern: '*'
+    transformers:
+      - trimprefix: cmd/builder/v
 
 targets:
   builder-config:
@@ -34,16 +36,6 @@ targets:
     spec:
       file: builder-config.yaml
       matchpattern: '[0-9]+\.[0-9]+\.[0-9]+'
-
-  ci-builder:
-    name: Bump CI builder to v{{ source "collector" }}
-    kind: file
-    scmid: default
-    sourceid: collector
-    spec:
-      file: .github/workflows/ci.yaml
-      matchpattern: '(run:\s+go install go\.opentelemetry\.io/collector/cmd/builder@v)[0-9]+\.[0-9]+\.[0-9]+'
-      replacepattern: '${1}{{ source "collector" }}'
 
   makefile-ocb:
     name: Bump Makefile OCB to v{{ source "collector" }}

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,7 +46,9 @@ jobs:
           go-version-file: 'metricsgenreceiver/go.mod'
 
       - name: Install OpenTelemetry builder
-        run: go install go.opentelemetry.io/collector/cmd/builder@v0.139.0
+        run: |
+          OCB_VERSION=$(sed -n 's/^OCB_VERSION ?= //p' Makefile)
+          go install "go.opentelemetry.io/collector/cmd/builder@v${OCB_VERSION}"
 
       - name: Build binary
         env:


### PR DESCRIPTION
A first scheduled **Update OTel Collector** workflow run failed https://github.com/elastic/metricsgenreceiver/actions/runs/27676040372

## Identified Problems

- Updatecli detected builder releases like `cmd/builder/v0.154.0`, but targets expected only `0.154.0`, producing invalid versions such as `vcmd/builder/v0.154.0`.
- Updatecli attempted to update `.github/workflows/ci.yaml`, which GitHub blocks when using the default `GITHUB_TOKEN` because workflow-file updates require elevated workflow permissions.

## Solution

- Normalize the Updatecli source with `trimprefix: cmd/builder/v`, so targets receive `0.x.y`.
- Keep `OCB_VERSION` centralized in `Makefile`.
- Make CI read `OCB_VERSION` from `Makefile` instead of hardcoding the builder version.
- Remove the Updatecli target that modified `.github/workflows/ci.yaml`.

## Reasoning

This avoids granting Updatecli broader workflow-write credentials for a routine dependency bump. The automation can keep using the default `GITHUB_TOKEN`, while CI still builds with the bumped OCB version through `Makefile`.