### PR TITLE
fix(ci): fall back to GitHub token for OTel tag workflow

### DIFF
--- a/.github/workflows/tag-otel-bump.yaml
+++ b/.github/workflows/tag-otel-bump.yaml
@@ -18,7 +18,7 @@ jobs:
         with:
           ref: main
           fetch-depth: 0
-          token: ${{ secrets.RELEASE_BOT_TOKEN }}
+          token: ${{ secrets.RELEASE_BOT_TOKEN || github.token }}
 
       - run: |
           latest=$(git tag -l 'v*.*.*' --sort=-v:refname | sed -n '1p')


### PR DESCRIPTION
## Summary
- Fix the OTel bump tagging workflow when `RELEASE_BOT_TOKEN` is not configured.
- Fall back to the built-in GitHub Actions token.