### PR TITLE
perf(receiver): precompute per-series variation strategy and precision

### DIFF
--- a/metricsgenreceiver/internal/distribution/instance_variation.go
+++ b/metricsgenreceiver/internal/distribution/instance_variation.go
@@ -38,7 +38,41 @@ const (
 // Implementations must be stateless: keeping per-series state would violate the project's
 // bounded-memory design principle.
 type InstanceVariationStrategy interface {
-	ApplyNumber(v pmetric.NumberDataPoint, instanceID int, identityHash uint64, metric pmetric.Metric, precision map[string]int, opts InstanceVariationOptions)
+	ApplyNumber(v pmetric.NumberDataPoint, instanceID int, identityHash uint64, metric pmetric.Metric, precision NumberPrecision, opts InstanceVariationOptions)
+}
+
+// NumberPrecision is the decimal precision resolved for a metric family. It is
+// resolved once per data point series (see NumberSeriesPlan) so the emission hot
+// path does not perform a map lookup on every data point.
+type NumberPrecision struct {
+	Decimals int
+	Set      bool
+}
+
+func resolvePrecision(metric pmetric.Metric, precision map[string]int) NumberPrecision {
+	if precision == nil {
+		return NumberPrecision{}
+	}
+	d, ok := precision[metric.Name()]
+	return NumberPrecision{Decimals: d, Set: ok}
+}
+
+// NumberSeriesPlan captures the per-series variation context that is stable across
+// instances and intervals for a given data point index: the resolved variation
+// strategy and decimal precision. Resolving these once at startup keeps the
+// per-emit hot path free of map lookups and strategy dispatch.
+type NumberSeriesPlan struct {
+	strategy  InstanceVariationStrategy
+	precision NumberPrecision
+}
+
+// PlanNumberSeries resolves the variation strategy and precision for a number metric
+// once so the receiver can reuse it for every instance and every interval.
+func PlanNumberSeries(metric pmetric.Metric, hints map[string]MetricGenerationHint, precision map[string]int) NumberSeriesPlan {
+	return NumberSeriesPlan{
+		strategy:  strategyFor(metric, hints),
+		precision: resolvePrecision(metric, precision),
+	}
 }
 
 var instanceVariations = map[GenerationHintClass]InstanceVariationStrategy{
@@ -56,7 +90,7 @@ var instanceVariations = map[GenerationHintClass]InstanceVariationStrategy{
 // variation is inferred from the metric shape. identityHash must be the value returned by
 // IdentityHash for this data point.
 func ApplyInstanceVariation(v pmetric.NumberDataPoint, instanceID int, identityHash uint64, metric pmetric.Metric, hints map[string]MetricGenerationHint, precision map[string]int, opts InstanceVariationOptions) {
-	strategyFor(metric, hints).ApplyNumber(v, instanceID, identityHash, metric, precision, opts)
+	strategyFor(metric, hints).ApplyNumber(v, instanceID, identityHash, metric, resolvePrecision(metric, precision), opts)
 }
 
 // InstanceVariationOptions contains timing information used for stateless,
@@ -75,12 +109,17 @@ type InstanceVariationOptions struct {
 type InstanceEmitOptions struct {
 	InstanceID   int
 	IdentityHash uint64
-	Hints        map[string]MetricGenerationHint
-	Precision    map[string]int
-	Variation    InstanceVariationOptions
-	Rand         *rand.Rand
-	Dist         DistributionCfg
-	ExpHistoGen  *expohistogen.Generator
+	// Plan holds the per-series strategy and precision resolved once at startup.
+	// When its strategy is set, the NumberDataPoint path uses it and avoids the
+	// per-emit Hints/Precision map lookups. Hints and Precision remain as a fallback
+	// for callers that do not precompute a plan.
+	Plan        NumberSeriesPlan
+	Hints       map[string]MetricGenerationHint
+	Precision   map[string]int
+	Variation   InstanceVariationOptions
+	Rand        *rand.Rand
+	Dist        DistributionCfg
+	ExpHistoGen *expohistogen.Generator
 }
 
 // EmitForInstance is the single entry point the receiver uses to emit a data point for an
@@ -88,7 +127,11 @@ type InstanceEmitOptions struct {
 func EmitForInstance(dataPoint dp.DataPoint, metric pmetric.Metric, opts InstanceEmitOptions) {
 	switch v := dataPoint.(type) {
 	case pmetric.NumberDataPoint:
-		ApplyInstanceVariation(v, opts.InstanceID, opts.IdentityHash, metric, opts.Hints, opts.Precision, opts.Variation)
+		if opts.Plan.strategy != nil {
+			opts.Plan.strategy.ApplyNumber(v, opts.InstanceID, opts.IdentityHash, metric, opts.Plan.precision, opts.Variation)
+		} else {
+			ApplyInstanceVariation(v, opts.InstanceID, opts.IdentityHash, metric, opts.Hints, opts.Precision, opts.Variation)
+		}
 	case pmetric.ExponentialHistogramDataPoint:
 		ApplyExponentialHistogramVariation(v, opts.InstanceID, opts.IdentityHash)
 	default:
@@ -120,7 +163,7 @@ func defaultInstanceVariationFor(metric pmetric.Metric) InstanceVariationStrateg
 
 type noInstanceVariation struct{}
 
-func (noInstanceVariation) ApplyNumber(pmetric.NumberDataPoint, int, uint64, pmetric.Metric, map[string]int, InstanceVariationOptions) {
+func (noInstanceVariation) ApplyNumber(pmetric.NumberDataPoint, int, uint64, pmetric.Metric, NumberPrecision, InstanceVariationOptions) {
 }
 
 type boundedMultiplierVariation struct {
@@ -144,7 +187,7 @@ func counterVariation() boundedMultiplierVariation {
 	}
 }
 
-func (s boundedMultiplierVariation) ApplyNumber(v pmetric.NumberDataPoint, instanceID int, identityHash uint64, metric pmetric.Metric, precision map[string]int, opts InstanceVariationOptions) {
+func (s boundedMultiplierVariation) ApplyNumber(v pmetric.NumberDataPoint, instanceID int, identityHash uint64, metric pmetric.Metric, precision NumberPrecision, opts InstanceVariationOptions) {
 	current := currentNumberDataPointValue(v)
 	if current == 0 {
 		return
@@ -156,7 +199,7 @@ func (s boundedMultiplierVariation) ApplyNumber(v pmetric.NumberDataPoint, insta
 	} else {
 		next = s.applyNonCumulativeVariation(current, identityHash, instanceID, instanceUnit, opts)
 	}
-	writeNumberDataPoint(v, next, metric, precision)
+	writeNumberDataPoint(v, next, precision)
 }
 
 func (s boundedMultiplierVariation) applyCumulativeCounterVariation(current float64, identityHash uint64, instanceID int, instanceUnit float64, opts InstanceVariationOptions) float64 {
@@ -181,7 +224,7 @@ type currentCountVariation struct {
 	maxOffset int64
 }
 
-func (s currentCountVariation) ApplyNumber(v pmetric.NumberDataPoint, instanceID int, identityHash uint64, metric pmetric.Metric, precision map[string]int, opts InstanceVariationOptions) {
+func (s currentCountVariation) ApplyNumber(v pmetric.NumberDataPoint, instanceID int, identityHash uint64, metric pmetric.Metric, precision NumberPrecision, opts InstanceVariationOptions) {
 	current := currentNumberDataPointValue(v)
 	span := s.maxOffset - s.minOffset + 1
 	if span <= 0 {
@@ -193,7 +236,7 @@ func (s currentCountVariation) ApplyNumber(v pmetric.NumberDataPoint, instanceID
 	instanceUnit := hashToUnitInterval(mixInstanceID(identityHash, instanceID))
 	multiplier := stableGaugeMultiplier(instanceUnit)
 	next := math.Max(0, current*multiplier+float64(offset))
-	writeNumberDataPoint(v, next, metric, precision)
+	writeNumberDataPoint(v, next, precision)
 }
 
 func stableGaugeMultiplier(instanceUnit float64) float64 {
@@ -284,11 +327,11 @@ func lerp(start, end, fraction float64) float64 {
 	return start + (end-start)*fraction
 }
 
-func writeNumberDataPoint(v pmetric.NumberDataPoint, next float64, metric pmetric.Metric, precision map[string]int) {
+func writeNumberDataPoint(v pmetric.NumberDataPoint, next float64, precision NumberPrecision) {
 	switch v.ValueType() {
 	case pmetric.NumberDataPointValueTypeDouble:
-		if p, ok := precision[metric.Name()]; ok {
-			next = roundToPrecision(next, p)
+		if precision.Set {
+			next = roundToPrecision(next, precision.Decimals)
 		}
 		v.SetDoubleValue(next)
 	case pmetric.NumberDataPointValueTypeInt:

--- a/metricsgenreceiver/internal/distribution/instance_variation_test.go
+++ b/metricsgenreceiver/internal/distribution/instance_variation_test.go
@@ -298,6 +298,88 @@ func TestDefaultInstanceVariationForUnhintedMetrics(t *testing.T) {
 	assert.NotEqual(t, dpA.DoubleValue(), dpB.DoubleValue())
 }
 
+func TestEmitForInstanceWithPlannedNumberSeriesMatchesFallback(t *testing.T) {
+	start := time.Unix(1000, 0)
+	variation := InstanceVariationOptions{
+		Timestamp:        start.Add(5 * time.Minute),
+		StartTime:        start,
+		Interval:         30 * time.Second,
+		CounterBaseDelta: 100,
+	}
+
+	tests := []struct {
+		name      string
+		hints     map[string]MetricGenerationHint
+		precision map[string]int
+		build     func() (pmetric.Metric, pmetric.NumberDataPoint)
+		assert    func(t *testing.T, planned pmetric.NumberDataPoint, fallback pmetric.NumberDataPoint)
+	}{
+		{
+			name: "hinted slow gauge uses planned precision",
+			hints: map[string]MetricGenerationHint{
+				"test.slow_gauge": {Class: GenerationHintSlowGauge},
+			},
+			precision: map[string]int{"test.slow_gauge": 2},
+			build: func() (pmetric.Metric, pmetric.NumberDataPoint) {
+				return newGaugeDoubleMetric("test.slow_gauge", 42.123)
+			},
+			assert: func(t *testing.T, planned pmetric.NumberDataPoint, fallback pmetric.NumberDataPoint) {
+				assert.Equal(t, fallback.DoubleValue(), planned.DoubleValue())
+				assert.Equal(t, roundToPrecision(planned.DoubleValue(), 2), planned.DoubleValue())
+			},
+		},
+		{
+			name: "hinted current count uses planned strategy",
+			hints: map[string]MetricGenerationHint{
+				"test.current_count": {Class: GenerationHintCurrentCount},
+			},
+			build: func() (pmetric.Metric, pmetric.NumberDataPoint) {
+				return newGaugeIntMetric("test.current_count", 10)
+			},
+			assert: func(t *testing.T, planned pmetric.NumberDataPoint, fallback pmetric.NumberDataPoint) {
+				assert.Equal(t, fallback.IntValue(), planned.IntValue())
+			},
+		},
+		{
+			name:      "unhinted cumulative counter keeps runtime metric semantics",
+			precision: map[string]int{"test.unhinted_counter": 0},
+			build: func() (pmetric.Metric, pmetric.NumberDataPoint) {
+				return newCumulativeDoubleSumMetric("test.unhinted_counter", 1000.25)
+			},
+			assert: func(t *testing.T, planned pmetric.NumberDataPoint, fallback pmetric.NumberDataPoint) {
+				assert.Equal(t, fallback.DoubleValue(), planned.DoubleValue())
+				assert.Equal(t, roundToPrecision(planned.DoubleValue(), 0), planned.DoubleValue())
+			},
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			plannedMetric, plannedDP := tc.build()
+			fallbackMetric, fallbackDP := tc.build()
+			plannedDP.Attributes().PutStr("series", "a")
+			fallbackDP.Attributes().PutStr("series", "a")
+			identityHash := IdentityHash(plannedMetric.Name(), plannedDP.Attributes())
+
+			EmitForInstance(plannedDP, plannedMetric, InstanceEmitOptions{
+				InstanceID:   7,
+				IdentityHash: identityHash,
+				Plan:         PlanNumberSeries(plannedMetric, tc.hints, tc.precision),
+				Variation:    variation,
+			})
+			EmitForInstance(fallbackDP, fallbackMetric, InstanceEmitOptions{
+				InstanceID:   7,
+				IdentityHash: identityHash,
+				Hints:        tc.hints,
+				Precision:    tc.precision,
+				Variation:    variation,
+			})
+
+			tc.assert(t, plannedDP, fallbackDP)
+		})
+	}
+}
+
 func newGaugeDoubleMetric(name string, value float64) (pmetric.Metric, pmetric.NumberDataPoint) {
 	metric := pmetric.NewMetric()
 	metric.SetName(name)

--- a/metricsgenreceiver/receiver.go
+++ b/metricsgenreceiver/receiver.go
@@ -52,6 +52,11 @@ type Scenario struct {
 	// the order ForEachDataPoint visits them. Precomputed once so the per-instance emission path
 	// avoids re-hashing the attribute set on every tick.
 	seriesIdentityHashes []uint64
+	// seriesPlans holds the resolved per-series variation strategy and precision for each number
+	// data point, indexed like seriesIdentityHashes. Precomputed once so the per-instance emission
+	// path avoids per-data-point hint/precision map lookups and strategy dispatch. Entries for
+	// non-number data points carry a zero-value plan and are unused.
+	seriesPlans []distribution.NumberSeriesPlan
 }
 
 type scenarioInstance struct {
@@ -163,19 +168,25 @@ func newMetricsGenReceiver(cfg *Config, set receiver.Settings) (*MetricsGenRecei
 				resource: resource,
 			}
 		}
+		precision := distribution.InferPrecision(&metrics)
 		seriesIdentityHashes := make([]uint64, metrics.DataPointCount())
+		seriesPlans := make([]distribution.NumberSeriesPlan, metrics.DataPointCount())
 		dp.ForEachDataPoint(&metrics, func(idx int, _ pcommon.Resource, _ pcommon.InstrumentationScope, m pmetric.Metric, dataPoint dp.DataPoint) {
 			seriesIdentityHashes[idx] = distribution.IdentityHash(m.Name(), dataPoint.Attributes())
+			if _, isNumber := dataPoint.(pmetric.NumberDataPoint); isNumber {
+				seriesPlans[idx] = distribution.PlanNumberSeries(m, generationHints, precision)
+			}
 		})
 		scenarios = append(scenarios, Scenario{
 			config:                    scn,
 			metricsTemplate:           &metrics,
 			instances:                 instances,
-			precision:                 distribution.InferPrecision(&metrics),
+			precision:                 precision,
 			generationHints:           generationHints,
 			nextReplacementInstanceID: scn.Scale,
 			churnRate:                 newChurnRate(scn.Churn, scn.Scale, cfg.Interval),
 			seriesIdentityHashes:      seriesIdentityHashes,
+			seriesPlans:               seriesPlans,
 		})
 	}
 
@@ -392,6 +403,7 @@ func (r *MetricsGenReceiver) produceMetricsForInstance(ctx context.Context, rng 
 		distribution.EmitForInstance(dataPoint, m, distribution.InstanceEmitOptions{
 			InstanceID:   instance.id,
 			IdentityHash: scn.seriesIdentityHashes[idx],
+			Plan:         scn.seriesPlans[idx],
 			Hints:        scn.generationHints,
 			Precision:    scn.precision,
 			Variation: distribution.InstanceVariationOptions{


### PR DESCRIPTION
## Summary

The per-instance emission hot path resolved the per-data-point variation strategy and decimal precision via map lookups on **every data point, for every instance, on every interval** — even though both are fully determined by the metric and are stable across instances and intervals.

This precomputes them once per template data point at scenario setup into a `NumberSeriesPlan` (alongside the existing `seriesIdentityHashes`) and reuses it during emission, removing the `hints` / `instanceVariations` / `precision` map lookups and the strategy dispatch from the hot loop. The previous map-lookup path is retained as a fallback for callers that do not precompute a plan, and generated output is unchanged — the existing value-exact receiver tests pass, and a new test asserts the planned path matches the fallback path.

CPU profiling of the `builtin/hostmetrics` scenario into the `nop` exporter shows the `strategyFor`, `runtime.mapaccess2_faststr`, and `ApplyInstanceVariation` dispatch frames removed from the emission path, improving single-threaded generation throughput by ~8–9% (~4.89M → ~5.31M dp/s at scale 100).