### PR TITLE
feat(bench): add benchmark suite and CI performance tracking

### DIFF
--- a/.github/templates/bench-comment.md
+++ b/.github/templates/bench-comment.md
@@ -1,0 +1,28 @@
+## Benchmark Results
+
+**Base:** `${BASE_SHORT}` → **HEAD:** `${HEAD_SHORT}`
+
+```
+${BENCHSTAT_OUT}
+```
+
+<details>
+<summary>Raw base output</summary>
+
+```
+${RAW_BASE}
+```
+
+</details>
+
+<details>
+<summary>Raw HEAD output</summary>
+
+```
+${RAW_HEAD}
+```
+
+</details>
+
+---
+*Last updated for commit `${HEAD_SHORT}`*

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -1,0 +1,82 @@
+name: Benchmark
+
+on:
+  pull_request:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: bench-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  benchmark:
+    name: Benchmark Comparison
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+
+      - name: Set up Go
+        uses: actions/setup-go@v6
+        with:
+          go-version-file: 'metricsgenreceiver/go.mod'
+
+      - name: Install benchstat
+        run: go install golang.org/x/perf/cmd/benchstat@latest
+
+      # Both runs happen sequentially in this job on the same runner to eliminate
+      # cross-machine variance. No caching: comparing results from different runner
+      # instances introduces noise that can look like a regression.
+      - name: Benchmark base branch
+        run: |
+          git checkout ${{ github.event.pull_request.base.sha }}
+          cd metricsgenreceiver
+          go test -run='^$' -bench=BenchmarkMetricsGenReceiver -benchtime=1x -count=10 -timeout=20m . \
+            | tee ../bench-base.txt
+
+      - name: Benchmark PR HEAD
+        run: |
+          git checkout ${{ github.event.pull_request.head.sha }}
+          cd metricsgenreceiver
+          go test -run='^$' -bench=BenchmarkMetricsGenReceiver -benchtime=1x -count=10 -timeout=20m . \
+            | tee ../bench-head.txt
+
+      - name: Build comment body
+        id: comment
+        run: |
+          export BENCHSTAT_OUT=$(benchstat bench-base.txt bench-head.txt 2>&1) || true
+          export BASE_SHORT="${{ github.event.pull_request.base.sha }}"
+          export BASE_SHORT="${BASE_SHORT:0:8}"
+          export HEAD_SHORT="${{ github.event.pull_request.head.sha }}"
+          export HEAD_SHORT="${HEAD_SHORT:0:8}"
+          export RAW_BASE=$(cat bench-base.txt)
+          export RAW_HEAD=$(cat bench-head.txt)
+
+          {
+            echo 'body<<BODY_DELIMITER'
+            envsubst '$BENCHSTAT_OUT $BASE_SHORT $HEAD_SHORT $RAW_BASE $RAW_HEAD' \
+              < .github/templates/bench-comment.md
+            echo 'BODY_DELIMITER'
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Find existing comment
+        uses: peter-evans/find-comment@v4
+        id: find-comment
+        with:
+          issue-number: ${{ github.event.pull_request.number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: '## Benchmark Results'
+
+      - name: Post or update benchmark comment
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ github.event.pull_request.number }}
+          edit-mode: replace
+          body: ${{ steps.comment.outputs.body }}

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,26 @@ OCB_VERSION ?= 0.154.0
 test:
 	cd metricsgenreceiver && go test ./...
 
+.PHONY: bench
+bench:
+	cd metricsgenreceiver && go test -run='^$$' -bench=BenchmarkMetricsGenReceiver \
+	  -benchtime=1x -count=10 -timeout=20m -v .
+
+# Micro-benchmarks use time-based benchtime: these are sub-microsecond operations
+# that need many iterations for stable numbers. -benchtime=1x would give 1 sample.
+.PHONY: bench-micro
+bench-micro:
+	cd metricsgenreceiver && go test -run='^$$' -bench=BenchmarkForEachDataPoint \
+	  -benchtime=5s -benchmem -count=5 ./...
+
+.PHONY: bench-profile
+bench-profile:
+	cd metricsgenreceiver && go test -run='^$$' \
+	  -bench=BenchmarkMetricsGenReceiver/hostmetrics \
+	  -benchtime=3x -cpuprofile=cpu.prof -memprofile=mem.prof -timeout=10m .
+	@echo "CPU profile: go tool pprof -http=:8080 metricsgenreceiver/cpu.prof"
+	@echo "Mem profile: go tool pprof -http=:8080 metricsgenreceiver/mem.prof"
+
 .PHONY: install-ocb
 install-ocb:
 	curl --proto '=https' --tlsv1.2 -fL -o ocb \

--- a/metricsgenreceiver/bench_test.go
+++ b/metricsgenreceiver/bench_test.go
@@ -1,0 +1,173 @@
+package metricsgenreceiver
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/elastic/metricsgenreceiver/metricsgenreceiver/internal/distribution"
+	"go.opentelemetry.io/collector/consumer"
+	"go.opentelemetry.io/collector/pdata/pmetric"
+	"go.opentelemetry.io/collector/receiver/receivertest"
+)
+
+type nopConsumer struct {
+	dps atomic.Uint64
+}
+
+func (c *nopConsumer) ConsumeMetrics(_ context.Context, md pmetric.Metrics) error {
+	c.dps.Add(uint64(md.DataPointCount()))
+	return nil
+}
+
+func (c *nopConsumer) Capabilities() consumer.Capabilities {
+	return consumer.Capabilities{MutatesData: false}
+}
+
+// benchBaseConfig returns a Config with a fixed 10-minute window at 10s intervals (60 ticks).
+// Callers append exactly one ScenarioCfg before passing to runBench.
+func benchBaseConfig() Config {
+	start := time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC)
+	return Config{
+		StartTime:    start,
+		EndTime:      start.Add(10 * time.Minute),
+		Interval:     10 * time.Second,
+		Seed:         42,
+		Distribution: distribution.DefaultDistribution,
+	}
+}
+
+func runBench(b *testing.B, cfg Config) {
+	b.Helper()
+	factory := NewFactory()
+	b.ReportAllocs()
+
+	for i := 0; i < b.N; i++ {
+		b.StopTimer()
+		nc := &nopConsumer{}
+		cfgCopy := cfg
+		rcv, err := factory.CreateMetrics(context.Background(), receivertest.NewNopSettings(typ), &cfgCopy, nc)
+		if err != nil {
+			b.Fatal(err)
+		}
+		b.StartTimer()
+
+		start := time.Now()
+		if err := rcv.Start(context.Background(), nil); err != nil {
+			b.Fatal(err)
+		}
+		waitForCompletion(rcv)
+		elapsed := time.Since(start)
+
+		b.StopTimer()
+		if err := rcv.Shutdown(context.Background()); err != nil {
+			b.Fatal(err)
+		}
+
+		got := nc.dps.Load()
+		if got == 0 {
+			b.Fatal("benchmark produced 0 data points — receiver may have exited early or config is invalid")
+		}
+		b.ReportMetric(float64(got)/elapsed.Seconds(), "dps/sec")
+		b.Logf("data points: %d", got)
+	}
+}
+
+func BenchmarkMetricsGenReceiver(b *testing.B) {
+	// per-template sub-benchmarks at representative scales
+
+	b.Run("hostmetrics", func(b *testing.B) {
+		cfg := benchBaseConfig()
+		cfg.Scenarios = []ScenarioCfg{{Path: "builtin/hostmetrics", Scale: 100}}
+		runBench(b, cfg)
+	})
+
+	b.Run("kubeletstats-node", func(b *testing.B) {
+		cfg := benchBaseConfig()
+		cfg.Scenarios = []ScenarioCfg{{Path: "builtin/kubeletstats-node", Scale: 10}}
+		runBench(b, cfg)
+	})
+
+	b.Run("kubeletstats-pod", func(b *testing.B) {
+		cfg := benchBaseConfig()
+		cfg.Scenarios = []ScenarioCfg{{Path: "builtin/kubeletstats-pod", Scale: 100}}
+		runBench(b, cfg)
+	})
+
+	b.Run("elasticapm-service", func(b *testing.B) {
+		cfg := benchBaseConfig()
+		cfg.Scenarios = []ScenarioCfg{{Path: "builtin/elasticapm-service-metrics", Scale: 100}}
+		runBench(b, cfg)
+	})
+
+	b.Run("elasticapm-span-dest", func(b *testing.B) {
+		cfg := benchBaseConfig()
+		cfg.Scenarios = []ScenarioCfg{{
+			Path:         "builtin/elasticapm-span-destination-metrics",
+			Scale:        100,
+			TemplateVars: map[string]any{"destinations": 5},
+		}}
+		runBench(b, cfg)
+	})
+
+	b.Run("elasticapm-transaction", func(b *testing.B) {
+		cfg := benchBaseConfig()
+		cfg.Scenarios = []ScenarioCfg{{
+			Path:         "builtin/elasticapm-transaction-metrics",
+			Scale:        100,
+			TemplateVars: map[string]any{"services": 10, "transactions": 10},
+		}}
+		runBench(b, cfg)
+	})
+
+	b.Run("nginx", func(b *testing.B) {
+		cfg := benchBaseConfig()
+		cfg.Scenarios = []ScenarioCfg{{Path: "builtin/nginx", Scale: 100}}
+		runBench(b, cfg)
+	})
+
+	b.Run("node_exporter", func(b *testing.B) {
+		cfg := benchBaseConfig()
+		cfg.Scenarios = []ScenarioCfg{{Path: "builtin/node_exporter", Scale: 100}}
+		runBench(b, cfg)
+	})
+
+	// cross-cutting variants using hostmetrics as the control
+
+	b.Run("hostmetrics-concurrency", func(b *testing.B) {
+		cfg := benchBaseConfig()
+		cfg.Scenarios = []ScenarioCfg{{Path: "builtin/hostmetrics", Scale: 100, Concurrency: 4}}
+		runBench(b, cfg)
+	})
+
+	b.Run("hostmetrics-churn", func(b *testing.B) {
+		cfg := benchBaseConfig()
+		cfg.Scenarios = []ScenarioCfg{{
+			Path:  "builtin/hostmetrics",
+			Scale: 100,
+			Churn: &ChurnCfg{SamplesPerSeries: 10},
+		}}
+		runBench(b, cfg)
+	})
+
+	b.Run("hostmetrics-expohisto", func(b *testing.B) {
+		cfg := benchBaseConfig()
+		cfg.Scenarios = []ScenarioCfg{{
+			Path:              "builtin/hostmetrics",
+			Scale:             100,
+			HistogramOverride: "exponential",
+		}}
+		runBench(b, cfg)
+	})
+
+	b.Run("hostmetrics-cumulative", func(b *testing.B) {
+		cfg := benchBaseConfig()
+		cfg.Scenarios = []ScenarioCfg{{
+			Path:                "builtin/hostmetrics",
+			Scale:               100,
+			TemporalityOverride: "cumulative",
+		}}
+		runBench(b, cfg)
+	})
+}

--- a/metricsgenreceiver/export_test.go
+++ b/metricsgenreceiver/export_test.go
@@ -1,0 +1,9 @@
+package metricsgenreceiver
+
+import "go.opentelemetry.io/collector/receiver"
+
+// waitForCompletion blocks until the receiver's generation goroutine exits.
+// Used by benchmarks to time only the generation phase, not setup/teardown.
+func waitForCompletion(r receiver.Metrics) {
+	r.(*MetricsGenReceiver).wg.Wait()
+}

--- a/metricsgenreceiver/internal/dp/datapoint_test.go
+++ b/metricsgenreceiver/internal/dp/datapoint_test.go
@@ -8,6 +8,35 @@ import (
 	"go.opentelemetry.io/collector/pdata/pmetric"
 )
 
+func buildBenchMetrics() pmetric.Metrics {
+	metrics := pmetric.NewMetrics()
+	sm := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty()
+	add := func(n int, setup func(pmetric.Metric)) {
+		for i := 0; i < n; i++ {
+			setup(sm.Metrics().AppendEmpty())
+		}
+	}
+	add(20, func(m pmetric.Metric) { m.SetEmptyGauge().DataPoints().AppendEmpty() })
+	add(20, func(m pmetric.Metric) { m.SetEmptySum().DataPoints().AppendEmpty() })
+	add(20, func(m pmetric.Metric) { m.SetEmptyHistogram().DataPoints().AppendEmpty() })
+	add(20, func(m pmetric.Metric) { m.SetEmptyExponentialHistogram().DataPoints().AppendEmpty() })
+	add(20, func(m pmetric.Metric) { m.SetEmptySummary().DataPoints().AppendEmpty() })
+	return metrics // 100 data points across all metric types
+}
+
+// BenchmarkForEachDataPoint pins the per-call cost of the iteration helper.
+// Expected: 1 alloc/data point — interface boxing of the concrete pdata type into
+// the DataPoint interface argument. Any increase above this baseline is a regression
+// in the iteration code itself. Decreasing it would require removing the interface.
+func BenchmarkForEachDataPoint(b *testing.B) {
+	metrics := buildBenchMetrics()
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		ForEachDataPoint(&metrics, func(int, pcommon.Resource, pcommon.InstrumentationScope, pmetric.Metric, DataPoint) {})
+	}
+}
+
 func TestForEachDataPointIndexes(t *testing.T) {
 	metrics := pmetric.NewMetrics()
 	scopeMetrics := metrics.ResourceMetrics().AppendEmpty().ScopeMetrics().AppendEmpty()


### PR DESCRIPTION
## Summary

This PR adds end-to-end benchmarking infrastructure in order to be able to catch performance regressions. More specifically we added:

- **Go benchmark tests** (`bench_test.go`) covering all 8 built-in scenarios at representative scales, plus 4 cross-cutting variants that isolate specific codepaths (goroutine concurrency, series churn, exponential histograms, cumulative temporality).
- **`BenchmarkForEachDataPoint`** micro-benchmark that pins the 1 alloc/dp baseline on the core iteration helper in `internal/dp/`.
- **`export_test.go`** exposing `waitForCompletion` so benchmarks can time only the generation phase without modifying the public API.
- **Makefile targets**: `make bench`, `make bench-micro`, `make bench-profile`.
- **CI workflow** (`.github/workflows/bench.yaml`) that runs base branch and PR head sequentially on the same runner (no cross-machine variance), then posts a `benchstat` diff as a PR comment.

### Why same-runner, no caching

The base branch results are not cached by SHA.
Comparing runs from different CI runner instances introduces machine-to-machine variance that looks like regressions.
Both runs happen sequentially in a single job, guaranteeing the same hardware.

### Benchmark results (M4 Pro, single run)

| Scenario | dps/sec |
|---|---|
| hostmetrics/100 | 4.5M |
| node_exporter/100 | 4.8M |
| kubeletstats-pod/100 | 3.3M |
| elasticapm-transaction/100 | 2.5M |
| hostmetrics-concurrency (4×) | 10.2M |