### PR TITLE
feat(hostmetrics): add exclude_host_ip_mac template flag

### DIFF
--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -6,7 +6,6 @@ on:
 
 permissions:
   contents: read
-  issues: write
   pull-requests: write
 
 concurrency:

--- a/.github/workflows/bench.yaml
+++ b/.github/workflows/bench.yaml
@@ -6,6 +6,7 @@ on:
 
 permissions:
   contents: read
+  issues: write
   pull-requests: write
 
 concurrency:

--- a/metricsgenreceiver/bench_test.go
+++ b/metricsgenreceiver/bench_test.go
@@ -170,4 +170,14 @@ func BenchmarkMetricsGenReceiver(b *testing.B) {
 		}}
 		runBench(b, cfg)
 	})
+
+	b.Run("hostmetrics-exclude-host-ip-mac", func(b *testing.B) {
+		cfg := benchBaseConfig()
+		cfg.Scenarios = []ScenarioCfg{{
+			Path:         "builtin/hostmetrics",
+			Scale:        100,
+			TemplateVars: map[string]any{"exclude_host_ip_mac": true},
+		}}
+		runBench(b, cfg)
+	})
 }

--- a/metricsgenreceiver/internal/metricstmpl/builtin/hostmetrics-resource-attributes.json
+++ b/metricsgenreceiver/internal/metricstmpl/builtin/hostmetrics-resource-attributes.json
@@ -8,7 +8,9 @@
             "value": {
               "stringValue": "host-{{.InstanceID}}"
             }
-          },
+          }
+          {{if not .Vars.exclude_host_ip_mac}}
+          ,
           {
             "key": "host.ip",
             "value": {
@@ -81,6 +83,7 @@
               }
             }
           }
+          {{end}}
         ]
       }
     }

--- a/metricsgenreceiver/internal/metricstmpl/builtin/hostmetrics.json
+++ b/metricsgenreceiver/internal/metricstmpl/builtin/hostmetrics.json
@@ -21,6 +21,7 @@
               "stringValue": "arm64"
             }
           },
+          {{if not .exclude_host_ip_mac}}
           {
             "key": "host.ip",
             "value": {
@@ -45,6 +46,7 @@
               }
             }
           },
+          {{end}}
           {
             "key": "os.description",
             "value": {
@@ -1052,6 +1054,7 @@
               "stringValue": "arm64"
             }
           },
+          {{if not .exclude_host_ip_mac}}
           {
             "key": "host.ip",
             "value": {
@@ -1076,6 +1079,7 @@
               }
             }
           },
+          {{end}}
           {
             "key": "os.description",
             "value": {
@@ -1234,6 +1238,7 @@
               "stringValue": "arm64"
             }
           },
+          {{if not .exclude_host_ip_mac}}
           {
             "key": "host.ip",
             "value": {
@@ -1258,6 +1263,7 @@
               }
             }
           },
+          {{end}}
           {
             "key": "os.description",
             "value": {
@@ -1526,6 +1532,7 @@
               "stringValue": "arm64"
             }
           },
+          {{if not .exclude_host_ip_mac}}
           {
             "key": "host.ip",
             "value": {
@@ -1550,6 +1557,7 @@
               }
             }
           },
+          {{end}}
           {
             "key": "os.description",
             "value": {
@@ -2218,6 +2226,7 @@
               "stringValue": "arm64"
             }
           },
+          {{if not .exclude_host_ip_mac}}
           {
             "key": "host.ip",
             "value": {
@@ -2242,6 +2251,7 @@
               }
             }
           },
+          {{end}}
           {
             "key": "os.description",
             "value": {
@@ -2385,6 +2395,7 @@
               "stringValue": "arm64"
             }
           },
+          {{if not .exclude_host_ip_mac}}
           {
             "key": "host.ip",
             "value": {
@@ -2409,6 +2420,7 @@
               }
             }
           },
+          {{end}}
           {
             "key": "os.description",
             "value": {
@@ -2809,6 +2821,7 @@
               "stringValue": "arm64"
             }
           },
+          {{if not .exclude_host_ip_mac}}
           {
             "key": "host.ip",
             "value": {
@@ -2833,6 +2846,7 @@
               }
             }
           },
+          {{end}}
           {
             "key": "os.description",
             "value": {

--- a/metricsgenreceiver/receiver_test.go
+++ b/metricsgenreceiver/receiver_test.go
@@ -200,17 +200,22 @@ func TestReceiverExcludeHostIPMAC(t *testing.T) {
 			allMetrics := sink.AllMetrics()
 			require.NotEmpty(t, allMetrics)
 
+			wantIPMACAssertion := assert.False
+			if test.wantIPMAC {
+				wantIPMACAssertion = assert.True
+			}
+
 			for _, md := range allMetrics {
 				for i := 0; i < md.ResourceMetrics().Len(); i++ {
 					attrs := md.ResourceMetrics().At(i).Resource().Attributes()
 
 					_, hasName := attrs.Get("host.name")
-					require.True(t, hasName, "host.name must always be present")
+					assert.True(t, hasName, "host.name must always be present")
 
 					_, hasIP := attrs.Get("host.ip")
 					_, hasMAC := attrs.Get("host.mac")
-					require.Equal(t, test.wantIPMAC, hasIP, "host.ip presence")
-					require.Equal(t, test.wantIPMAC, hasMAC, "host.mac presence")
+					wantIPMACAssertion(t, hasIP, "host.ip presence")
+					wantIPMACAssertion(t, hasMAC, "host.mac presence")
 				}
 			}
 		})

--- a/metricsgenreceiver/receiver_test.go
+++ b/metricsgenreceiver/receiver_test.go
@@ -162,6 +162,61 @@ func TestReceiver(t *testing.T) {
 	}
 }
 
+func TestReceiverExcludeHostIPMAC(t *testing.T) {
+	tests := []struct {
+		name         string
+		templateVars map[string]any
+		wantIPMAC    bool
+	}{
+		{
+			name:         "default includes host.ip and host.mac",
+			templateVars: nil,
+			wantIPMAC:    true,
+		},
+		{
+			name:         "exclude_host_ip_mac true excludes host.ip and host.mac",
+			templateVars: map[string]any{"exclude_host_ip_mac": true},
+			wantIPMAC:    false,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			sink := new(consumertest.MetricsSink)
+
+			factory := NewFactory()
+			cfg := testdataConfigYamlAsMap()
+			cfg.Scenarios[0].Path = "builtin/hostmetrics"
+			cfg.Scenarios[0].TemplateVars = test.templateVars
+			rcv, err := factory.CreateMetrics(context.Background(), receivertest.NewNopSettings(typ), cfg, sink)
+			require.NoError(t, err)
+			require.NoError(t, rcv.Start(context.Background(), nil))
+
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				require.Greater(c, sink.DataPointCount(), 0)
+			}, 2*time.Second, time.Millisecond)
+			require.NoError(t, rcv.Shutdown(context.Background()))
+
+			allMetrics := sink.AllMetrics()
+			require.NotEmpty(t, allMetrics)
+
+			for _, md := range allMetrics {
+				for i := 0; i < md.ResourceMetrics().Len(); i++ {
+					attrs := md.ResourceMetrics().At(i).Resource().Attributes()
+
+					_, hasName := attrs.Get("host.name")
+					require.True(t, hasName, "host.name must always be present")
+
+					_, hasIP := attrs.Get("host.ip")
+					_, hasMAC := attrs.Get("host.mac")
+					require.Equal(t, test.wantIPMAC, hasIP, "host.ip presence")
+					require.Equal(t, test.wantIPMAC, hasMAC, "host.mac presence")
+				}
+			}
+		})
+	}
+}
+
 func TestReceiverAppliesGenerationHints(t *testing.T) {
 	sink := new(consumertest.MetricsSink)
 


### PR DESCRIPTION
### Summary

Conditionally emit hostmetrics data with or without `host.ip` and `host.mac` attributes, determined via `template_vars.exclude_host_ip_mac`.

Receiver example for dropping these values:

```yaml
receivers:
  metricsgen:
    start_now_minus: 240m
    interval: 10s
    interval_jitter_std_dev: 1ms
    real_time: false
    exit_after_end: true
    exit_after_end_timeout: 30s
    seed: 123
    scenarios:
      - path: builtin/hostmetrics
        scale: 1000
        template_vars:
          exclude_host_ip_mac: true
```

Note for reviewers: the workflow defined in `bench.yaml` appears to be failing, because we can't write in a PR in upstream from a workflow executed in a fork. I will take an action item in order to fix that in a follow-up PR.